### PR TITLE
AEA-3738 Restrict which GitHub envs can deploy to int and prod

### DIFF
--- a/cloudformation/env/int.json
+++ b/cloudformation/env/int.json
@@ -3,9 +3,9 @@
   "parameters": {
     "ci-resources": {
       "DeploySubjectClaimFilters": [
-        "repo:NHSDigital/prescriptionsforpatients:int",
-        "repo:NHSDigital/electronic-prescription-service-account-resources:int",
-        "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:int"
+        "repo:NHSDigital/prescriptionsforpatients:environment:int",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int",
+        "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:environment:int"
       ],
       "CheckVersionSubjectClaimFilters": [
         "repo:NHSDigital/prescriptionsforpatients:*",

--- a/cloudformation/env/int.json
+++ b/cloudformation/env/int.json
@@ -3,9 +3,9 @@
   "parameters": {
     "ci-resources": {
       "DeploySubjectClaimFilters": [
-        "repo:NHSDigital/prescriptionsforpatients:*",
-        "repo:NHSDigital/electronic-prescription-service-account-resources:*",
-        "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:*"
+        "repo:NHSDigital/prescriptionsforpatients:int",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:int",
+        "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:int"
       ],
       "CheckVersionSubjectClaimFilters": [
         "repo:NHSDigital/prescriptionsforpatients:*",

--- a/cloudformation/env/int.json
+++ b/cloudformation/env/int.json
@@ -4,7 +4,6 @@
     "ci-resources": {
       "DeploySubjectClaimFilters": [
         "repo:NHSDigital/prescriptionsforpatients:environment:int",
-        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int",
         "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int-account",
         "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int-ci",
         "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int-lambda",

--- a/cloudformation/env/int.json
+++ b/cloudformation/env/int.json
@@ -5,6 +5,9 @@
       "DeploySubjectClaimFilters": [
         "repo:NHSDigital/prescriptionsforpatients:environment:int",
         "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int-account",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int-ci",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:int-lambda",
         "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:environment:int"
       ],
       "CheckVersionSubjectClaimFilters": [

--- a/cloudformation/env/prod.json
+++ b/cloudformation/env/prod.json
@@ -3,9 +3,9 @@
   "parameters": {
     "ci-resources": {
       "DeploySubjectClaimFilters": [
-        "repo:NHSDigital/prescriptionsforpatients:*",
-        "repo:NHSDigital/electronic-prescription-service-account-resources:*",
-        "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:*"
+        "repo:NHSDigital/prescriptionsforpatients:prod",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:prod",
+        "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:prod"
       ],
       "CheckVersionSubjectClaimFilters": [
         "repo:NHSDigital/prescriptionsforpatients:*",

--- a/cloudformation/env/prod.json
+++ b/cloudformation/env/prod.json
@@ -5,6 +5,9 @@
       "DeploySubjectClaimFilters": [
         "repo:NHSDigital/prescriptionsforpatients:environment:prod",
         "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod-account",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod-ci",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod-lambda",
         "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:environment:prod"
       ],
       "CheckVersionSubjectClaimFilters": [

--- a/cloudformation/env/prod.json
+++ b/cloudformation/env/prod.json
@@ -3,9 +3,9 @@
   "parameters": {
     "ci-resources": {
       "DeploySubjectClaimFilters": [
-        "repo:NHSDigital/prescriptionsforpatients:prod",
-        "repo:NHSDigital/electronic-prescription-service-account-resources:prod",
-        "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:prod"
+        "repo:NHSDigital/prescriptionsforpatients:environment:prod",
+        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod",
+        "repo:NHSDigital/electronic-prescription-service-clinical-prescription-tracker:environment:prod"
       ],
       "CheckVersionSubjectClaimFilters": [
         "repo:NHSDigital/prescriptionsforpatients:*",

--- a/cloudformation/env/prod.json
+++ b/cloudformation/env/prod.json
@@ -4,7 +4,6 @@
     "ci-resources": {
       "DeploySubjectClaimFilters": [
         "repo:NHSDigital/prescriptionsforpatients:environment:prod",
-        "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod",
         "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod-account",
         "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod-ci",
         "repo:NHSDigital/electronic-prescription-service-account-resources:environment:prod-lambda",


### PR DESCRIPTION
## Summary

- Routine Change
- :robot: Operational or Infrastructure Change

### Details

Made SubjectClaimFilters more specific so that only int and prod Github envs can assume CloudFormationDeployRoles in int and prod, respectively.

## Reviews Required

**Check who should review this. Remove this line once this has been done**

- [x] Dev
- [ ] Test
- [ ] Tech Author
- [ ] Product Owner

## Review Checklist

:information_source: This section is to be filled in by the **reviewer**.

- [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
- [ ] I have reviewed any infrastructure changes listed in the workflow summary.
- [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
- [ ] I have ensured the jira ticket has been updated with the github pull request link
