### PR TITLE
add none filter for test report claim in other env apart from dev

### DIFF
--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -383,7 +383,25 @@ Resources:
                 aws:SourceAccount: !Ref "AWS::AccountId"
               ArnLike:
                 aws:SourceArn: !GetAtt TrustStoreBucket.Arn
-
+          - Effect: Allow
+            Principal:
+              Service: logging.s3.amazonaws.com
+            Action:
+              - s3:PutObject*
+            Resource:
+              - !Join [
+                  "",
+                  [
+                    !GetAtt AuditLoggingBucket.Arn,
+                    "/testreports/*",
+                  ],
+                ]
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref "AWS::AccountId"
+              ArnLike:
+                aws:SourceArn: !GetAtt TestReportsBucket.Arn
+  
   ##################################################
   # Splunk Delivery Stream Backup Bucket
   ##################################################

--- a/cloudformation/env/int.json
+++ b/cloudformation/env/int.json
@@ -19,6 +19,9 @@
       ],
       "PrepareChangesetClaimFilters": [
         "repo:NHSDigital/electronic-prescription-service-account-resources:*"
+      ],
+      "TestReportsClaimFilters": [
+        "NONE"
       ]
     },
     "account-resources": {},

--- a/cloudformation/env/prod.json
+++ b/cloudformation/env/prod.json
@@ -20,6 +20,9 @@
       ],
       "PrepareChangesetClaimFilters": [
         "repo:NHSDigital/electronic-prescription-service-account-resources:*"
+      ],
+      "TestReportsClaimFilters": [
+        "NONE"
       ]
     },
     "account-resources": {},

--- a/cloudformation/env/qa.json
+++ b/cloudformation/env/qa.json
@@ -18,6 +18,9 @@
       ],
       "PrepareChangesetClaimFilters": [
         "repo:NHSDigital/electronic-prescription-service-account-resources:*"
+      ],
+      "TestReportsClaimFilters": [
+        "NONE"
       ]
     },
     "account-resources": {},

--- a/cloudformation/env/ref.json
+++ b/cloudformation/env/ref.json
@@ -18,6 +18,9 @@
       ],
       "PrepareChangesetClaimFilters": [
         "repo:NHSDigital/electronic-prescription-service-account-resources:*"
+      ],
+      "TestReportsClaimFilters": [
+        "NONE"
       ]
     },
     "account-resources": {},


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- adds none filter for test reports in other environments except dev
- adds audit bucket permissions