### PR TITLE
AEA-3878 Create certificates for mutual TLS for PSU API - create secrets

### DIFF
--- a/SAMtemplates/lambda_resources.yaml
+++ b/SAMtemplates/lambda_resources.yaml
@@ -345,6 +345,9 @@ Resources:
               - !ImportValue account-resources:PfpCACertSecret
               - !ImportValue account-resources:PfpClientCertSecret
               - !ImportValue account-resources:PfpClientSandboxCertSecret
+              - !ImportValue account-resources:PsuCACertSecret
+              - !ImportValue account-resources:PsuClientCertSecret
+              - !ImportValue account-resources:PsuClientSandboxCertSecret
               - !ImportValue account-resources:SpinePublicCertificate
           - Effect: Allow 
             Action:
@@ -389,6 +392,9 @@ Resources:
                 \"${PfpCACertSecret}\", \
                 \"${PfpClientCertSecret}\", \
                 \"${PfpClientSandboxCertSecret}\", \
+                \"${PsuCACertSecret}\", \
+                \"${PsuClientCertSecret}\", \
+                \"${PsuClientSandboxCertSecret}\", \
                 \"${SpinePublicCertificate}\" ]}"
               - ClinicalTrackerCACertSecret: !ImportValue account-resources:ClinicalTrackerCACertSecret
                 ClinicalTrackerClientCertSecret: !ImportValue account-resources:ClinicalTrackerClientCertSecret
@@ -396,6 +402,9 @@ Resources:
                 PfpCACertSecret: !ImportValue account-resources:PfpCACertSecret
                 PfpClientCertSecret: !ImportValue account-resources:PfpClientCertSecret
                 PfpClientSandboxCertSecret: !ImportValue account-resources:PfpClientSandboxCertSecret
+                PsuCACertSecret: !ImportValue account-resources:PsuCACertSecret
+                PsuClientCertSecret: !ImportValue account-resources:PsuClientCertSecret
+                PsuClientSandboxCertSecret: !ImportValue account-resources:PsuClientSandboxCertSecret
                 SpinePublicCertificate: !ImportValue account-resources:SpinePublicCertificate          
     Metadata: 
       BuildMethod: esbuild

--- a/SAMtemplates/lambda_resources.yaml
+++ b/SAMtemplates/lambda_resources.yaml
@@ -345,9 +345,6 @@ Resources:
               - !ImportValue account-resources:PfpCACertSecret
               - !ImportValue account-resources:PfpClientCertSecret
               - !ImportValue account-resources:PfpClientSandboxCertSecret
-              - !ImportValue account-resources:PsuCACertSecret
-              - !ImportValue account-resources:PsuClientCertSecret
-              - !ImportValue account-resources:PsuClientSandboxCertSecret
               - !ImportValue account-resources:SpinePublicCertificate
           - Effect: Allow 
             Action:
@@ -392,9 +389,6 @@ Resources:
                 \"${PfpCACertSecret}\", \
                 \"${PfpClientCertSecret}\", \
                 \"${PfpClientSandboxCertSecret}\", \
-                \"${PsuCACertSecret}\", \
-                \"${PsuClientCertSecret}\", \
-                \"${PsuClientSandboxCertSecret}\", \
                 \"${SpinePublicCertificate}\" ]}"
               - ClinicalTrackerCACertSecret: !ImportValue account-resources:ClinicalTrackerCACertSecret
                 ClinicalTrackerClientCertSecret: !ImportValue account-resources:ClinicalTrackerClientCertSecret
@@ -402,9 +396,6 @@ Resources:
                 PfpCACertSecret: !ImportValue account-resources:PfpCACertSecret
                 PfpClientCertSecret: !ImportValue account-resources:PfpClientCertSecret
                 PfpClientSandboxCertSecret: !ImportValue account-resources:PfpClientSandboxCertSecret
-                PsuCACertSecret: !ImportValue account-resources:PsuCACertSecret
-                PsuClientCertSecret: !ImportValue account-resources:PsuClientCertSecret
-                PsuClientSandboxCertSecret: !ImportValue account-resources:PsuClientSandboxCertSecret
                 SpinePublicCertificate: !ImportValue account-resources:SpinePublicCertificate          
     Metadata: 
       BuildMethod: esbuild

--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -732,9 +732,9 @@ Resources:
       SecretString: ChangeMe
 
   ##################################################
-  # Prescription Status Update CA Secrets
+  # PSU CA Secrets
   ##################################################
-  PrescriptionStatusUpdateCAKeySecret:
+  PsuCAKeySecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -742,7 +742,7 @@ Resources:
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
-  PrescriptionStatusUpdateCACertSecret:
+  PsuCACertSecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -751,9 +751,9 @@ Resources:
       SecretString: ChangeMe
 
   ##################################################
-  # Prescription Status Update Client Secrets
+  # PSU Client Secrets
   ##################################################
-  PrescriptionStatusUpdateClientKeySecret:
+  PsuClientKeySecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -761,7 +761,7 @@ Resources:
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
-  PrescriptionStatusUpdateClientCertSecret:
+  PsuClientCertSecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -769,7 +769,7 @@ Resources:
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
-  PrescriptionStatusUpdateClientSandboxKeySecret:
+  PsuClientSandboxKeySecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -777,7 +777,7 @@ Resources:
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
-  PrescriptionStatusUpdateClientSandboxCertSecret:
+  PsuClientSandboxCertSecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -1105,55 +1105,55 @@ Outputs:
         ]
 
   ##################################################
-  # Prescription Status Update CA Secrets Outputs
+  # PSU CA Secrets Outputs
   ##################################################
-  PrescriptionStatusUpdateCAKeySecret:
+  PsuCAKeySecret:
     Description: ARN of the prescription status update CA key secret
-    Value: !GetAtt PrescriptionStatusUpdateCAKeySecret.Id
+    Value: !GetAtt PsuCAKeySecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "PrescriptionStatusUpdateCAKeySecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "PsuCAKeySecret"]]
 
-  PrescriptionStatusUpdateCACertSecret:
+  PsuCACertSecret:
     Description: ARN of the prescription status update CA cert secret
-    Value: !GetAtt PrescriptionStatusUpdateCACertSecret.Id
+    Value: !GetAtt PsuCACertSecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "PrescriptionStatusUpdateCACertSecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "PsuCACertSecret"]]
 
   ##################################################
-  # Prescription Status Update Client Secrets Outputs
+  # PSU Client Secrets Outputs
   ##################################################
-  PrescriptionStatusUpdateClientKeySecret:
+  PsuClientKeySecret:
     Description: ARN of the prescription status update client key secret
-    Value: !GetAtt PrescriptionStatusUpdateClientKeySecret.Id
+    Value: !GetAtt PsuClientKeySecret.Id
     Export:
       Name:
-        !Join [":", [!Ref "AWS::StackName", "PrescriptionStatusUpdateClientKeySecret"]]
+        !Join [":", [!Ref "AWS::StackName", "PsuClientKeySecret"]]
 
-  PrescriptionStatusUpdateClientCertSecret:
+  PsuClientCertSecret:
     Description: ARN of the prescription status update client cert secret
-    Value: !GetAtt PrescriptionStatusUpdateClientCertSecret.Id
+    Value: !GetAtt PsuClientCertSecret.Id
     Export:
       Name:
-        !Join [":", [!Ref "AWS::StackName", "PrescriptionStatusUpdateClientCertSecret"]]
+        !Join [":", [!Ref "AWS::StackName", "PsuClientCertSecret"]]
 
-  PrescriptionStatusUpdateClientSandboxKeySecret:
+  PsuClientSandboxKeySecret:
     Description: ARN of the prescription status update client key secret for sandbox
-    Value: !GetAtt PrescriptionStatusUpdateClientSandboxKeySecret.Id
+    Value: !GetAtt PsuClientSandboxKeySecret.Id
     Export:
       Name:
         !Join [
           ":",
-          [!Ref "AWS::StackName", "PrescriptionStatusUpdateClientSandboxKeySecret"],
+          [!Ref "AWS::StackName", "PsuClientSandboxKeySecret"],
         ]
 
-  PrescriptionStatusUpdateClientSandboxCertSecret:
+  PsuClientSandboxCertSecret:
     Description: ARN of the prescription status update client cert secret for sandbox
-    Value: !GetAtt PrescriptionStatusUpdateClientSandboxCertSecret.Id
+    Value: !GetAtt PsuClientSandboxCertSecret.Id
     Export:
       Name:
         !Join [
           ":",
-          [!Ref "AWS::StackName", "PrescriptionStatusUpdateClientSandboxCertSecret"],
+          [!Ref "AWS::StackName", "PsuClientSandboxCertSecret"],
         ]
 
   ##################################################

--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -1126,35 +1126,25 @@ Outputs:
     Description: ARN of the prescription status update client key secret
     Value: !GetAtt PsuClientKeySecret.Id
     Export:
-      Name:
-        !Join [":", [!Ref "AWS::StackName", "PsuClientKeySecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "PsuClientKeySecret"]]
 
   PsuClientCertSecret:
     Description: ARN of the prescription status update client cert secret
     Value: !GetAtt PsuClientCertSecret.Id
     Export:
-      Name:
-        !Join [":", [!Ref "AWS::StackName", "PsuClientCertSecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "PsuClientCertSecret"]]
 
   PsuClientSandboxKeySecret:
     Description: ARN of the prescription status update client key secret for sandbox
     Value: !GetAtt PsuClientSandboxKeySecret.Id
     Export:
-      Name:
-        !Join [
-          ":",
-          [!Ref "AWS::StackName", "PsuClientSandboxKeySecret"],
-        ]
+      Name: !Join [":", [!Ref "AWS::StackName", "PsuClientSandboxKeySecret"]]
 
   PsuClientSandboxCertSecret:
     Description: ARN of the prescription status update client cert secret for sandbox
     Value: !GetAtt PsuClientSandboxCertSecret.Id
     Export:
-      Name:
-        !Join [
-          ":",
-          [!Ref "AWS::StackName", "PsuClientSandboxCertSecret"],
-        ]
+      Name: !Join [":", [!Ref "AWS::StackName", "PsuClientSandboxCertSecret"]]
 
   ##################################################
   # Spine Secrets Outputs

--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -732,6 +732,60 @@ Resources:
       SecretString: ChangeMe
 
   ##################################################
+  # Prescription Status Update CA Secrets
+  ##################################################
+  PrescriptionStatusUpdateCAKeySecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Prescription status update CA private key
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  PrescriptionStatusUpdateCACertSecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Prescription status update CA secret
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  ##################################################
+  # Prescription Status Update Client Secrets
+  ##################################################
+  PrescriptionStatusUpdateClientKeySecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Prescription status update client private key
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  PrescriptionStatusUpdateClientCertSecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Prescription status update client cert
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  PrescriptionStatusUpdateClientSandboxKeySecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Prescription status update client sandbox private key
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  PrescriptionStatusUpdateClientSandboxCertSecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Prescription status update client sandbox cert
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  ##################################################
   # Spine Secrets
   ##################################################
   SpinePrivateKey:
@@ -1048,6 +1102,58 @@ Outputs:
         !Join [
           ":",
           [!Ref "AWS::StackName", "ClinicalTrackerClientSandboxCertSecret"],
+        ]
+
+  ##################################################
+  # Prescription Status Update CA Secrets Outputs
+  ##################################################
+  PrescriptionStatusUpdateCAKeySecret:
+    Description: ARN of the prescription status update CA key secret
+    Value: !GetAtt PrescriptionStatusUpdateCAKeySecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "PrescriptionStatusUpdateCAKeySecret"]]
+
+  PrescriptionStatusUpdateCACertSecret:
+    Description: ARN of the prescription status update CA cert secret
+    Value: !GetAtt PrescriptionStatusUpdateCACertSecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "PrescriptionStatusUpdateCACertSecret"]]
+
+  ##################################################
+  # Prescription Status Update Client Secrets Outputs
+  ##################################################
+  PrescriptionStatusUpdateClientKeySecret:
+    Description: ARN of the prescription status update client key secret
+    Value: !GetAtt PrescriptionStatusUpdateClientKeySecret.Id
+    Export:
+      Name:
+        !Join [":", [!Ref "AWS::StackName", "PrescriptionStatusUpdateClientKeySecret"]]
+
+  PrescriptionStatusUpdateClientCertSecret:
+    Description: ARN of the prescription status update client cert secret
+    Value: !GetAtt PrescriptionStatusUpdateClientCertSecret.Id
+    Export:
+      Name:
+        !Join [":", [!Ref "AWS::StackName", "PrescriptionStatusUpdateClientCertSecret"]]
+
+  PrescriptionStatusUpdateClientSandboxKeySecret:
+    Description: ARN of the prescription status update client key secret for sandbox
+    Value: !GetAtt PrescriptionStatusUpdateClientSandboxKeySecret.Id
+    Export:
+      Name:
+        !Join [
+          ":",
+          [!Ref "AWS::StackName", "PrescriptionStatusUpdateClientSandboxKeySecret"],
+        ]
+
+  PrescriptionStatusUpdateClientSandboxCertSecret:
+    Description: ARN of the prescription status update client cert secret for sandbox
+    Value: !GetAtt PrescriptionStatusUpdateClientSandboxCertSecret.Id
+    Export:
+      Name:
+        !Join [
+          ":",
+          [!Ref "AWS::StackName", "PrescriptionStatusUpdateClientSandboxCertSecret"],
         ]
 
   ##################################################

--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -1126,25 +1126,35 @@ Outputs:
     Description: ARN of the prescription status update client key secret
     Value: !GetAtt PsuClientKeySecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "PsuClientKeySecret"]]
+      Name:
+        !Join [":", [!Ref "AWS::StackName", "PsuClientKeySecret"]]
 
   PsuClientCertSecret:
     Description: ARN of the prescription status update client cert secret
     Value: !GetAtt PsuClientCertSecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "PsuClientCertSecret"]]
+      Name:
+        !Join [":", [!Ref "AWS::StackName", "PsuClientCertSecret"]]
 
   PsuClientSandboxKeySecret:
     Description: ARN of the prescription status update client key secret for sandbox
     Value: !GetAtt PsuClientSandboxKeySecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "PsuClientSandboxKeySecret"]]
+      Name:
+        !Join [
+          ":",
+          [!Ref "AWS::StackName", "PsuClientSandboxKeySecret"],
+        ]
 
   PsuClientSandboxCertSecret:
     Description: ARN of the prescription status update client cert secret for sandbox
     Value: !GetAtt PsuClientSandboxCertSecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "PsuClientSandboxCertSecret"]]
+      Name:
+        !Join [
+          ":",
+          [!Ref "AWS::StackName", "PsuClientSandboxCertSecret"],
+        ]
 
   ##################################################
   # Spine Secrets Outputs


### PR DESCRIPTION
## Summary

🎫 [AEA-3878](https://nhsd-jira.digital.nhs.uk/browse/AEA-3878) Create certificates for mutual TLS for PSU API - create secrets

- Routine Change

### Details

For the prescription status update service, we need certificates and keys created to enable mutual TLS communication to the API gateway endpoint to ensure communication is secure.

Create PSU secrets.