### PR TITLE
AEA-3878 Create certificates for mutual TLS for PSU API - use secrets

### DIFF
--- a/SAMtemplates/lambda_resources.yaml
+++ b/SAMtemplates/lambda_resources.yaml
@@ -345,6 +345,9 @@ Resources:
               - !ImportValue account-resources:PfpCACertSecret
               - !ImportValue account-resources:PfpClientCertSecret
               - !ImportValue account-resources:PfpClientSandboxCertSecret
+              - !ImportValue account-resources:PsuCACertSecret
+              - !ImportValue account-resources:PsuClientCertSecret
+              - !ImportValue account-resources:PsuClientSandboxCertSecret
               - !ImportValue account-resources:SpinePublicCertificate
           - Effect: Allow 
             Action:
@@ -389,6 +392,9 @@ Resources:
                 \"${PfpCACertSecret}\", \
                 \"${PfpClientCertSecret}\", \
                 \"${PfpClientSandboxCertSecret}\", \
+                \"${PsuCACertSecret}\", \
+                \"${PsuClientCertSecret}\", \
+                \"${PsuClientSandboxCertSecret}\", \
                 \"${SpinePublicCertificate}\" ]}"
               - ClinicalTrackerCACertSecret: !ImportValue account-resources:ClinicalTrackerCACertSecret
                 ClinicalTrackerClientCertSecret: !ImportValue account-resources:ClinicalTrackerClientCertSecret
@@ -396,6 +402,9 @@ Resources:
                 PfpCACertSecret: !ImportValue account-resources:PfpCACertSecret
                 PfpClientCertSecret: !ImportValue account-resources:PfpClientCertSecret
                 PfpClientSandboxCertSecret: !ImportValue account-resources:PfpClientSandboxCertSecret
+                PsuCACertSecret: !ImportValue account-resources:PsuCACertSecret
+                PsuClientCertSecret: !ImportValue account-resources:PsuClientCertSecret
+                PsuClientSandboxCertSecret: !ImportValue account-resources:PsuClientSandboxCertSecret
                 SpinePublicCertificate: !ImportValue account-resources:SpinePublicCertificate          
     Metadata: 
       BuildMethod: esbuild


### PR DESCRIPTION
## Summary

🎫 [AEA-3878](https://nhsd-jira.digital.nhs.uk/browse/AEA-3878) Create certificates for mutual TLS for PSU API - use secrets

- :robot: Operational or Infrastructure Change
- :warning: Potential issues that might be caused by this change

### Details

For the prescription status update service, we need certificates and keys created to enable mutual TLS communication to the API gateway endpoint to ensure communication is secure.

Use PSU secrets.