### PR TITLE
AEA-3907 Add DynamoDB permissions to the execution role

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -252,6 +252,17 @@ Resources:
               - scheduler:UntagResource
               - scheduler:UpdateSchedule
               - scheduler:ListTagsForResource
+              - dynamodb:GetItem
+              - dynamodb:Scan
+              - dynamodb:Query
+              - dynamodb:BatchGetItem
+              - dynamodb:DescribeTable
+              - dynamodb:GetRecords
+              - dynamodb:ListTables
+              - dynamodb:BatchWriteItem
+              - dynamodb:DeleteItem
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
 
             Resource: "*"
 

--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -252,17 +252,13 @@ Resources:
               - scheduler:UntagResource
               - scheduler:UpdateSchedule
               - scheduler:ListTagsForResource
-              - dynamodb:GetItem
-              - dynamodb:Scan
-              - dynamodb:Query
-              - dynamodb:BatchGetItem
+              - dynamodb:CreateTable
+              - dynamodb:DeleteTable
               - dynamodb:DescribeTable
-              - dynamodb:GetRecords
+              - dynamodb:UpdateTable
+              - dynamodb:TagResource
+              - dynamodb:UntagResource
               - dynamodb:ListTables
-              - dynamodb:BatchWriteItem
-              - dynamodb:DeleteItem
-              - dynamodb:PutItem
-              - dynamodb:UpdateItem
 
             Resource: "*"
 


### PR DESCRIPTION
## Summary

🎫 [AEA-3907](https://nhsd-jira.digital.nhs.uk/browse/AEA-3907) dynamodb permissions not added to execution role

- Routine Change

### Details

Add DynamoDB permissions to the execution role.