### PR TITLE
AEA-3978 Give the ci role access to all kms keys

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -115,6 +115,11 @@ Resources:
               - !ImportValue account-resources:PsuCAKeySecret
               - !ImportValue account-resources:PsuClientCertSecret
               - !ImportValue account-resources:PsuClientSandboxCertSecret
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource:
+              - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*"
 
   ##################################################
   # Cloudformation Execution Role


### PR DESCRIPTION
## Summary

🎫 [AEA-3978](https://nhsd-jira.digital.nhs.uk/browse/AEA-3978) Give the ci role access to all kms keys
- :robot: Operational or Infrastructure Change

### Details

Give the ci role access to all kms keys.