### PR TITLE
AEA-3899 Add required ssm permissions to CloudFormationExecutionRole.

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -310,6 +310,8 @@ Resources:
               - states:UpdateMapRun
               - states:UpdateStateMachine
               - states:UpdateStateMachineAlias
+              - ssm:PutParameter
+              - ssm:DeleteParameter
             Resource: "*"
 
   ##################################################

--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -312,6 +312,10 @@ Resources:
               - states:UpdateStateMachineAlias
               - ssm:PutParameter
               - ssm:DeleteParameter
+              - ssm:AddTagsToResource
+              - ssm:DescribeParameters
+              - ssm:ListTagsForResource
+              - ssm:RemoveTagsFromResource
             Resource: "*"
 
   ##################################################

--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -150,7 +150,8 @@ Resources:
             Action:
               - iam:PassRole
             Resource: !GetAtt CloudFormationExecutionRole.Arn
-
+  
+  # Handy reference for AWS permissions:
   # https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html
   GrantCloudFormationDeployAccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Adding ssm permissions to allow creation/deletion of Parameter Store params, to be used in toggling in state machines.
