### PR TITLE
Fix: [AEA-0000] - normalise headers for logging correlation ids from step functions

### DIFF
--- a/packages/splunkProcessor/src/splunkProcessor.js
+++ b/packages/splunkProcessor/src/splunkProcessor.js
@@ -124,10 +124,14 @@ function transformStepFunctionsLogEvent(logEvent) {
     */
     eventMessage = JSON.parse(logEvent.message)
     const input = JSON.parse(eventMessage.details.input)
-    eventMessage["apigw-request-id"] = input["headers"]["apigw-request-id"]
-    eventMessage["X-Amzn-Trace-Id"] = input["headers"]["X-Amzn-Trace-Id"]
-    eventMessage["x-correlation-id"] = input["headers"]["x-correlation-id"]
-    eventMessage["x-request-id"] = input["headers"]["x-request-id"]
+    const normalizedHeaders = {}
+    for (const key of Object.keys(input.headers)) {
+      normalizedHeaders[key.toLowerCase()] = input.headers[key]
+    }
+    eventMessage["apigw-request-id"] = normalizedHeaders["apigw-request-id"]
+    eventMessage["X-Amzn-Trace-Id"] = normalizedHeaders["x-amzn-trace-id"]
+    eventMessage["x-correlation-id"] = normalizedHeaders["x-correlation-id"]
+    eventMessage["x-request-id"] = normalizedHeaders["x-request-id"]
   } catch (_) {
     try {
       // something went wrong in the above so try and parse it to JSON

--- a/packages/splunkProcessor/tests/transformLogEvent.stepfunctions.test.js
+++ b/packages/splunkProcessor/tests/transformLogEvent.stepfunctions.test.js
@@ -163,4 +163,58 @@ describe("transformLogEvent tests for stepFunctions log groups", () => {
 
     expect(transformedLogEvent).toEqual(JSON.stringify(expectedResult))
   })
+
+  it("should parse correctly for stepfunctions when correlation fields do exist and are mixed case", async () => {
+    const logEvent = {
+      message: JSON.stringify({
+        field1: "foo",
+        field2: "bar",
+        details: {
+          input: JSON.stringify({
+            body: "foo",
+            headers: {
+              "apigw-request-id": "ac9ddfe0-030a-4bcd-b63b-d4d1a32381a0",
+              "X-Amzn-Trace-Id": "Root=1-6613feca-23ef52160d128597232a4c97",
+              "X-correlation-id": "b9156b99-13cc-4719-b832-73905e07e760",
+              "X-request-id": "a22cc83d-b40b-43a1-b5f7-71944cd498bc"
+            }
+          })
+        }
+      }),
+      id: 1
+    }
+    const logGroup = "/aws/stepfunctions/foo"
+    const accountNumber = 1234
+    const transformedLogEvent = await transformLogEvent(logEvent, logGroup, accountNumber)
+    const expectedResult = {
+      host: "AWS:AccountNumber:1234",
+      source: "AWS:LogGroup:/aws/stepfunctions/foo",
+      sourcetype: "aws:cloudwatch",
+      event: {
+        id: 1,
+        message: {
+          field1: "foo",
+          field2: "bar",
+          details: {
+            input: JSON.stringify({
+              body: "foo",
+              headers: {
+                "apigw-request-id": "ac9ddfe0-030a-4bcd-b63b-d4d1a32381a0",
+                "X-Amzn-Trace-Id": "Root=1-6613feca-23ef52160d128597232a4c97",
+                "X-correlation-id": "b9156b99-13cc-4719-b832-73905e07e760",
+                "X-request-id": "a22cc83d-b40b-43a1-b5f7-71944cd498bc"
+              }
+            })
+          },
+          "apigw-request-id": "ac9ddfe0-030a-4bcd-b63b-d4d1a32381a0",
+          "X-Amzn-Trace-Id": "Root=1-6613feca-23ef52160d128597232a4c97",
+          "x-correlation-id": "b9156b99-13cc-4719-b832-73905e07e760",
+          "x-request-id": "a22cc83d-b40b-43a1-b5f7-71944cd498bc",
+        }
+      }
+    }
+
+    expect(transformedLogEvent).toEqual(JSON.stringify(expectedResult))
+  })
+
 })


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- retrieve normalised headers for logging correlation ids for step functions