### PR TITLE
Fix: [AEA-0000] - change esbuild to bundle dependendencies

### DIFF
--- a/SAMtemplates/lambda_resources.yaml
+++ b/SAMtemplates/lambda_resources.yaml
@@ -218,6 +218,7 @@ Resources:
         Minify: true
         Target: "es2020"
         Sourcemap: true
+        packages: bundle
         EntryPoints:
           - splunkProcessor/src/splunkProcessor.js
 
@@ -404,6 +405,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         tsconfig: certificateChecker/tsconfig.json
+        packages: bundle
         EntryPoints:
           - certificateChecker/src/certificateChecker.ts
 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- change esbuild to bundle dependencies following default behavior in esbuild 0.22 - https://github.com/evanw/esbuild/releases/tag/v0.22.0