### PR TITLE
Fix: [AEA-4205] - redact step function logs before sending to splunk

### DIFF
--- a/packages/splunkProcessor/.vscode/settings.json
+++ b/packages/splunkProcessor/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "jest.jestCommandLine": "NODE_OPTIONS=--experimental-vm-modules  /workspaces/electronic-prescription-service-account-resources/node_modules/.bin/jest --no-cache"
+  "jest.jestCommandLine": "NODE_OPTIONS=--experimental-vm-modules  /workspaces/electronic-prescription-service-account-resources/node_modules/.bin/jest --no-cache",
+  "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+  "editor.formatOnSave": true,
+  "javascript.format.enable": true,
+  "typescript.format.enable": true
 }

--- a/packages/splunkProcessor/src/splunkProcessor.js
+++ b/packages/splunkProcessor/src/splunkProcessor.js
@@ -132,7 +132,7 @@ function transformStepFunctionsLogEvent(logEvent) {
     eventMessage["X-Amzn-Trace-Id"] = normalizedHeaders["x-amzn-trace-id"]
     eventMessage["x-correlation-id"] = normalizedHeaders["x-correlation-id"]
     eventMessage["x-request-id"] = normalizedHeaders["x-request-id"]
-} catch (_) {
+  } catch (_) {
     try {
       // something went wrong in the above so try and parse it to JSON
       eventMessage = JSON.parse(logEvent.message)

--- a/packages/splunkProcessor/src/splunkProcessor.js
+++ b/packages/splunkProcessor/src/splunkProcessor.js
@@ -132,7 +132,7 @@ function transformStepFunctionsLogEvent(logEvent) {
     eventMessage["X-Amzn-Trace-Id"] = normalizedHeaders["x-amzn-trace-id"]
     eventMessage["x-correlation-id"] = normalizedHeaders["x-correlation-id"]
     eventMessage["x-request-id"] = normalizedHeaders["x-request-id"]
-  } catch (_) {
+} catch (_) {
     try {
       // something went wrong in the above so try and parse it to JSON
       eventMessage = JSON.parse(logEvent.message)
@@ -140,6 +140,15 @@ function transformStepFunctionsLogEvent(logEvent) {
       // we cant parse it to JSON so just return the raw message
       eventMessage = logEvent.message
     }
+  }
+  if (typeof eventMessage.details?.output != "undefined") {
+    eventMessage.details.output = "redacted"
+  }
+  if (typeof eventMessage.details?.parameters != "undefined") {
+    eventMessage.details.parameters = "redacted"
+  }
+  if (typeof eventMessage.details?.input != "undefined") {
+    eventMessage.details.input = "redacted"
   }
   return eventMessage
 }

--- a/packages/splunkProcessor/tests/transformLogEvent.stepfunctions.test.js
+++ b/packages/splunkProcessor/tests/transformLogEvent.stepfunctions.test.js
@@ -38,15 +38,7 @@ describe("transformLogEvent tests for stepFunctions log groups", () => {
           field1: "foo",
           field2: "bar",
           details: {
-            input: JSON.stringify({
-              body: "foo",
-              headers: {
-                "apigw-request-id": "ac9ddfe0-030a-4bcd-b63b-d4d1a32381a0",
-                "X-Amzn-Trace-Id": "Root=1-6613feca-23ef52160d128597232a4c97",
-                "x-correlation-id": "b9156b99-13cc-4719-b832-73905e07e760",
-                "x-request-id": "a22cc83d-b40b-43a1-b5f7-71944cd498bc"
-              }
-            })
+            input: "redacted"
           },
           "apigw-request-id": "ac9ddfe0-030a-4bcd-b63b-d4d1a32381a0",
           "X-Amzn-Trace-Id": "Root=1-6613feca-23ef52160d128597232a4c97",
@@ -85,9 +77,7 @@ describe("transformLogEvent tests for stepFunctions log groups", () => {
           field1: "foo",
           field2: "bar",
           details: {
-            input: JSON.stringify({
-              body: "foo"
-            })
+            input: "redacted"
           }
         }
       }
@@ -126,13 +116,7 @@ describe("transformLogEvent tests for stepFunctions log groups", () => {
           field1: "foo",
           field2: "bar",
           details: {
-            input: JSON.stringify({
-              body: "foo",
-              headers: {
-                "x-correlation-id": "b9156b99-13cc-4719-b832-73905e07e760",
-                "x-request-id": "a22cc83d-b40b-43a1-b5f7-71944cd498bc"
-              }
-            })
+            input: "redacted"
           },
           "x-correlation-id": "b9156b99-13cc-4719-b832-73905e07e760",
           "x-request-id": "a22cc83d-b40b-43a1-b5f7-71944cd498bc",
@@ -196,15 +180,7 @@ describe("transformLogEvent tests for stepFunctions log groups", () => {
           field1: "foo",
           field2: "bar",
           details: {
-            input: JSON.stringify({
-              body: "foo",
-              headers: {
-                "apigw-request-id": "ac9ddfe0-030a-4bcd-b63b-d4d1a32381a0",
-                "X-Amzn-Trace-Id": "Root=1-6613feca-23ef52160d128597232a4c97",
-                "X-correlation-id": "b9156b99-13cc-4719-b832-73905e07e760",
-                "X-request-id": "a22cc83d-b40b-43a1-b5f7-71944cd498bc"
-              }
-            })
+            input: "redacted"
           },
           "apigw-request-id": "ac9ddfe0-030a-4bcd-b63b-d4d1a32381a0",
           "X-Amzn-Trace-Id": "Root=1-6613feca-23ef52160d128597232a4c97",
@@ -216,5 +192,141 @@ describe("transformLogEvent tests for stepFunctions log groups", () => {
 
     expect(transformedLogEvent).toEqual(JSON.stringify(expectedResult))
   })
+
+  it("should redact input for stepfunctions", async () => {
+    const logEvent = {
+      message: JSON.stringify({
+        field1: "foo",
+        field2: "bar",
+        details: {
+          input: JSON.stringify({
+            body: "foo"
+          })
+        }
+      }),
+      id: 1
+    }
+    const logGroup = "/aws/stepfunctions/foo"
+    const accountNumber = 1234
+    const transformedLogEvent = await transformLogEvent(logEvent, logGroup, accountNumber)
+    const expectedResult = {
+      host: "AWS:AccountNumber:1234",
+      source: "AWS:LogGroup:/aws/stepfunctions/foo",
+      sourcetype: "aws:cloudwatch",
+      event: {
+        id: 1,
+        message: {
+          field1: "foo",
+          field2: "bar",
+          details: {
+            input: "redacted"
+          }
+        }
+      }
+    }
+
+    expect(transformedLogEvent).toEqual(JSON.stringify(expectedResult))
+  })
+
+  it("should redact parameters for stepfunctions", async () => {
+    const logEvent = {
+      message: JSON.stringify({
+        field1: "foo",
+        field2: "bar",
+        details: {
+          parameters: JSON.stringify({
+            body: "foo"
+          })
+        }
+      }),
+      id: 1
+    }
+    const logGroup = "/aws/stepfunctions/foo"
+    const accountNumber = 1234
+    const transformedLogEvent = await transformLogEvent(logEvent, logGroup, accountNumber)
+    const expectedResult = {
+      host: "AWS:AccountNumber:1234",
+      source: "AWS:LogGroup:/aws/stepfunctions/foo",
+      sourcetype: "aws:cloudwatch",
+      event: {
+        id: 1,
+        message: {
+          field1: "foo",
+          field2: "bar",
+          details: {
+            parameters: "redacted"
+          }
+        }
+      }
+    }
+
+    expect(transformedLogEvent).toEqual(JSON.stringify(expectedResult))
+  })
+
+  it("should redact output for stepfunctions", async () => {
+    const logEvent = {
+      message: JSON.stringify({
+        field1: "foo",
+        field2: "bar",
+        details: {
+          output: JSON.stringify({
+            body: "foo"
+          })
+        }
+      }),
+      id: 1
+    }
+    const logGroup = "/aws/stepfunctions/foo"
+    const accountNumber = 1234
+    const transformedLogEvent = await transformLogEvent(logEvent, logGroup, accountNumber)
+    const expectedResult = {
+      host: "AWS:AccountNumber:1234",
+      source: "AWS:LogGroup:/aws/stepfunctions/foo",
+      sourcetype: "aws:cloudwatch",
+      event: {
+        id: 1,
+        message: {
+          field1: "foo",
+          field2: "bar",
+          details: {
+            output: "redacted"
+          }
+        }
+      }
+    }
+
+    expect(transformedLogEvent).toEqual(JSON.stringify(expectedResult))
+  })
+
+  it("should parse correctly for stepfunctions when nothing needs redacting", async () => {
+    const logEvent = {
+      message: JSON.stringify({
+        field1: "foo",
+        field2: "bar",
+        details: {
+        }
+      }),
+      id: 1
+    }
+    const logGroup = "/aws/stepfunctions/foo"
+    const accountNumber = 1234
+    const transformedLogEvent = await transformLogEvent(logEvent, logGroup, accountNumber)
+    const expectedResult = {
+      host: "AWS:AccountNumber:1234",
+      source: "AWS:LogGroup:/aws/stepfunctions/foo",
+      sourcetype: "aws:cloudwatch",
+      event: {
+        id: 1,
+        message: {
+          field1: "foo",
+          field2: "bar",
+          details: {},
+        }
+      }
+    }
+
+    expect(transformedLogEvent).toEqual(JSON.stringify(expectedResult))
+  })
+
 
 })


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- redact input, output, parameters from step function logs before sending to splunk