### PR TITLE
Update: [AEA-4291] - Create certificates for mutual TLS for EPS FHIR - create secrets

### DIFF
--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -803,56 +803,56 @@ Resources:
       SecretString: ChangeMe
 
   ##################################################
-  # EPS CA Secrets
+  # EPS FHIR Facade CA Secrets
   ##################################################
-  EpsCAKeySecret:
+  FhirFacadeCAKeySecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: EPS CA private key
+      Description: EPS FHIR facade CA private key
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
-  EpsCACertSecret:
+  FhirFacadeCACertSecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: EPS CA secret
+      Description: EPS FHIR facade CA secret
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
   ##################################################
-  # EPS Client Secrets
+  # EPS FHIR Facade Client Secrets
   ##################################################
-  EpsClientKeySecret:
+  FhirFacadeClientKeySecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: EPS client private key
+      Description: EPS FHIR facade client private key
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
-  EpsClientCertSecret:
+  FhirFacadeClientCertSecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: EPS client cert
+      Description: EPS FHIR facade client cert
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
-  EpsClientSandboxKeySecret:
+  FhirFacadeClientSandboxKeySecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: EPS client sandbox private key
+      Description: EPS FHIR facade client sandbox private key
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
-  EpsClientSandboxCertSecret:
+  FhirFacadeClientSandboxCertSecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: EPS client sandbox cert
+      Description: EPS FHIR facade client sandbox cert
       KmsKeyId: alias/SecretsKMSKeyAlias
       SecretString: ChangeMe
 
@@ -1279,46 +1279,46 @@ Outputs:
       Name: !Join [":", [!Ref "AWS::StackName", "PsuClientSandboxCertSecret"]]
 
   ##################################################
-  # EPS CA Secrets Outputs
+  # EPS FHIR Facade CA Secrets Outputs
   ##################################################
-  EpsCAKeySecret:
-    Description: ARN of the prescription status update CA key secret
-    Value: !GetAtt EpsCAKeySecret.Id
+  FhirFacadeCAKeySecret:
+    Description: ARN of the EPS FHIR facade CA key secret
+    Value: !GetAtt FhirFacadeCAKeySecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "EpsCAKeySecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "FhirFacadeCAKeySecret"]]
 
-  EpsCACertSecret:
-    Description: ARN of the prescription status update CA cert secret
-    Value: !GetAtt EpsCACertSecret.Id
+  FhirFacadeCACertSecret:
+    Description: ARN of the EPS FHIR facade CA cert secret
+    Value: !GetAtt FhirFacadeCACertSecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "EpsCACertSecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "FhirFacadeCACertSecret"]]
 
   ##################################################
-  # EPS Client Secrets Outputs
+  # EPS FHIR Facade Client Secrets Outputs
   ##################################################
-  EpsClientKeySecret:
-    Description: ARN of the prescription status update client key secret
-    Value: !GetAtt EpsClientKeySecret.Id
+  FhirFacadeClientKeySecret:
+    Description: ARN of the EPS FHIR facade client key secret
+    Value: !GetAtt FhirFacadeClientKeySecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "EpsClientKeySecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "FhirFacadeClientKeySecret"]]
 
-  EpsClientCertSecret:
-    Description: ARN of the prescription status update client cert secret
-    Value: !GetAtt EpsClientCertSecret.Id
+  FhirFacadeClientCertSecret:
+    Description: ARN of the EPS FHIR facade client cert secret
+    Value: !GetAtt FhirFacadeClientCertSecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "EpsClientCertSecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "FhirFacadeClientCertSecret"]]
 
-  EpsClientSandboxKeySecret:
-    Description: ARN of the prescription status update client key secret for sandbox
-    Value: !GetAtt EpsClientSandboxKeySecret.Id
+  FhirFacadeClientSandboxKeySecret:
+    Description: ARN of the EPS FHIR facade client key secret for sandbox
+    Value: !GetAtt FhirFacadeClientSandboxKeySecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "EpsClientSandboxKeySecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "FhirFacadeClientSandboxKeySecret"]]
 
-  EpsClientSandboxCertSecret:
-    Description: ARN of the prescription status update client cert secret for sandbox
-    Value: !GetAtt EpsClientSandboxCertSecret.Id
+  FhirFacadeClientSandboxCertSecret:
+    Description: ARN of the EPS FHIR facade client cert secret for sandbox
+    Value: !GetAtt FhirFacadeClientSandboxCertSecret.Id
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "EpsClientSandboxCertSecret"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "FhirFacadeClientSandboxCertSecret"]]
 
   ##################################################
   # Spine Secrets Outputs

--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -803,6 +803,60 @@ Resources:
       SecretString: ChangeMe
 
   ##################################################
+  # EPS CA Secrets
+  ##################################################
+  EpsCAKeySecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: EPS CA private key
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  EpsCACertSecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: EPS CA secret
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  ##################################################
+  # EPS Client Secrets
+  ##################################################
+  EpsClientKeySecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: EPS client private key
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  EpsClientCertSecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: EPS client cert
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  EpsClientSandboxKeySecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: EPS client sandbox private key
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  EpsClientSandboxCertSecret:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: EPS client sandbox cert
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+
+  ##################################################
   # Spine Secrets
   ##################################################
   SpinePrivateKey:
@@ -1223,6 +1277,48 @@ Outputs:
     Value: !GetAtt PsuClientSandboxCertSecret.Id
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", "PsuClientSandboxCertSecret"]]
+
+  ##################################################
+  # EPS CA Secrets Outputs
+  ##################################################
+  EpsCAKeySecret:
+    Description: ARN of the prescription status update CA key secret
+    Value: !GetAtt EpsCAKeySecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "EpsCAKeySecret"]]
+
+  EpsCACertSecret:
+    Description: ARN of the prescription status update CA cert secret
+    Value: !GetAtt EpsCACertSecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "EpsCACertSecret"]]
+
+  ##################################################
+  # EPS Client Secrets Outputs
+  ##################################################
+  EpsClientKeySecret:
+    Description: ARN of the prescription status update client key secret
+    Value: !GetAtt EpsClientKeySecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "EpsClientKeySecret"]]
+
+  EpsClientCertSecret:
+    Description: ARN of the prescription status update client cert secret
+    Value: !GetAtt EpsClientCertSecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "EpsClientCertSecret"]]
+
+  EpsClientSandboxKeySecret:
+    Description: ARN of the prescription status update client key secret for sandbox
+    Value: !GetAtt EpsClientSandboxKeySecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "EpsClientSandboxKeySecret"]]
+
+  EpsClientSandboxCertSecret:
+    Description: ARN of the prescription status update client cert secret for sandbox
+    Value: !GetAtt EpsClientSandboxCertSecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "EpsClientSandboxCertSecret"]]
 
   ##################################################
   # Spine Secrets Outputs


### PR DESCRIPTION
## Summary

🎫 [AEA-4291](https://nhsd-jira.digital.nhs.uk/browse/AEA-4291) Create certificates for mutual TLS for EPS FHIR

- :robot: Operational or Infrastructure Change
- :warning: Potential issues that might be caused by this change

### Details

For the EPS FHIR, we need certificates and keys to enable mutual TLS communication with the API gateway endpoint, ensuring that the communication is secure.