### PR TITLE
Chore: [AEA-3992] - Add PITR permission to access policy

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -404,6 +404,7 @@ Resources:
               - dynamodb:DeleteTable
               - dynamodb:DescribeTable
               - dynamodb:UpdateTable
+              - dynamodb:UpdateContinuousBackups
               - dynamodb:TagResource
               - dynamodb:UntagResource
               - dynamodb:ListTables


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change

### Details

Required for [THIS](https://github.com/NHSDigital/eps-prescription-status-update-api/pull/620) PR to build successfully.

In order to deploy stacks with PITR, we need to update the permissions granted by the policy.