### PR TITLE
Chore: [AEA-4382] - Add the pattern for ECS CloudWatchLogsKmsKey to the account-resources stack

### DIFF
--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -90,6 +90,7 @@ Resources:
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/kinesisfirehose/*"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda-insights*"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/stepfunctions/*"
+                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/ecs/*"
                   - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:artilleryio-log-group/artilleryio-cluster"
           - Sid: Allow API Gateway Role
             Effect: Allow


### PR DESCRIPTION
## Summary

🎫 [AEA-4382](https://nhsd-jira.digital.nhs.uk/browse/AEA-4382) Add the pattern for ECS CloudWatchLogsKmsKey to the account-resources stack

- Routine Change

### Details

Add the pattern for ECS CloudWatchLogsKmsKey to the account-resources stack