### PR TITLE
Chore: [AEA-4440] - Update Slack Alerter alarm name parsing

### DIFF
--- a/packages/slackAlerter/src/slackAlerter.ts
+++ b/packages/slackAlerter/src/slackAlerter.ts
@@ -62,13 +62,18 @@ const processRecord = async (record: SQSRecord): Promise<void> => {
 }
 
 const generateSlackMessageContent = (cloudWatchMessage: CloudWatchAlarm): CloudWatchAlertMessageContent => {
-  // To fully populate the message, alert names should be in the format "<stack_name> - <Alarm Name>"
-  // e.g. "psu - Lambda Errors".
+  // To fully populate the message, alarm names should be in the format "<StackName>_<ResourceName>_<Metric>"
+  // e.g. "psu-pr-123_TestLambda_Errors".
   let stack, alarmName
-  if (cloudWatchMessage.AlarmName.includes(" - ")){
-    const parts = cloudWatchMessage.AlarmName.split("-")
-    stack = parts[0].trim()
-    alarmName = parts[1].trim()
+  if (cloudWatchMessage.AlarmName.includes("_")){
+    const parts = cloudWatchMessage.AlarmName.split("_")
+    if (parts.length === 3) {
+      stack = parts[0]
+      alarmName = `${parts[1]} ${parts[2]}`
+    } else {
+      stack = "unknown"
+      alarmName = cloudWatchMessage.AlarmName
+    }
   } else {
     stack = "unknown"
     alarmName = cloudWatchMessage.AlarmName

--- a/packages/slackAlerter/tests/testContentFormatting.test.ts
+++ b/packages/slackAlerter/tests/testContentFormatting.test.ts
@@ -19,57 +19,57 @@ describe("formatTrigger", () => {
     {
       description: "returns a correctly formatted trigger when called",
       mockTrigger: generateMockTrigger(90061),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 1 day, 1 hour, 1 minute, 1 second."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 1 day, 1 hour, 1 minute, 1 second."
     },
     {
       description: "returns correctly formatted day in period when called",
       mockTrigger: generateMockTrigger(86400),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 1 day."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 1 day."
     },
     {
       description: "returns correctly formatted days in period when called",
       mockTrigger: generateMockTrigger(172800),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 2 days."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 2 days."
     },
     {
       description: "returns correctly formatted hour in period when called",
       mockTrigger: generateMockTrigger(3600),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 1 hour."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 1 hour."
     },
     {
       description: "returns correctly formatted hours in period when called",
       mockTrigger: generateMockTrigger(7200),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 2 hours."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 2 hours."
     },
     {
       description: "returns correctly formatted minute in period when called",
       mockTrigger: generateMockTrigger(60),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 1 minute."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 1 minute."
     },
     {
       description: "returns correctly formatted minutes in period when called",
       mockTrigger: generateMockTrigger(120),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 2 minutes."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 2 minutes."
     },
     {
       description: "returns correctly formatted second in period when called",
       mockTrigger: generateMockTrigger(1),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 1 second."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 1 second."
     },
     {
       description: "returns correctly formatted seconds in period when called",
       mockTrigger: generateMockTrigger(2),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 2 seconds."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 2 seconds."
     },
     {
       description: "returns a correctly formatted period when called with mixed units",
       mockTrigger: generateMockTrigger(86460),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 1 day, 1 minute."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 1 day, 1 minute."
     },
     {
       description: "returns a correctly formatted period when called with mixed units",
       mockTrigger: generateMockTrigger(3601),
-      expected: "SUM Invocations GreaterThanThreshold 1 for 1 period(s) of 1 hour, 1 second."
+      expected: "SUM Errors GreaterThanThreshold 1 for 1 period(s) of 1 hour, 1 second."
     }
   ]
   testCases.forEach(({description, mockTrigger, expected}) => {

--- a/packages/slackAlerter/tests/utils/testUtils.ts
+++ b/packages/slackAlerter/tests/utils/testUtils.ts
@@ -52,14 +52,14 @@ the threshold (1.0) (minimum 1 datapoint for OK -> ALARM transition).`,
 
 export const generateMockTrigger = (period: number): Trigger => {
   return {
-    "MetricName": "Invocations",
+    "MetricName": "Errors",
     "Namespace": "AWS/Lambda",
     "StatisticType": "Statistic",
     "Statistic": "SUM",
     "Unit": null,
     "Dimensions": [
       {
-        "value": "snsTest",
+        "value": "TestLambda",
         "name": "FunctionName"
       }
     ],


### PR DESCRIPTION
## Summary
- Routine Change
- :robot: Operational or Infrastructure Change

### Details
- Updates alarm name parsing to match new `<StackName>_<ResourceName>_<Metric>` format
- Updates tests
