### PR TITLE
Fix: [AEA-4067] - Add missing secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,21 @@ jobs:
     secrets:
       cf_create_changeset_role: ${{ secrets.QA_CLOUD_FORMATION_CREATE_CHANGESET_ROLE }}
       cf_deploy_role: ${{ secrets.QA_CLOUD_FORMATION_DEPLOY_ROLE }}
+
+  deploy_ref_stacks:
+    needs: [get_commit_id, package_code, tag_release, deploy_dev_stacks]
+    uses: ./.github/workflows/release_all_stacks.yml
+    with:
+      target_environment: ref
+      version: ${{ needs.tag_release.outputs.version_tag }}
+      change_set_version: ${{ needs.tag_release.outputs.change_set_version }}
+      execute_change_set: true
+      lambda_stack_suffix: ""
+      artifact_bucket_prefix: ${{needs.tag_release.outputs.version_tag}}
+      version_number: ${{needs.tag_release.outputs.version_tag}}
+      commit_id: ${{ needs.get_commit_id.outputs.commit_id }}
+      lambda_insights_log_group_name: /aws/lambda-insights
+      deploy_artillery: true
+    secrets:
+      cf_create_changeset_role: ${{ secrets.REF_CLOUD_FORMATION_CREATE_CHANGESET_ROLE }}
+      cf_deploy_role: ${{ secrets.REF_CLOUD_FORMATION_DEPLOY_ROLE }}

--- a/.vscode/account-resources.code-workspace
+++ b/.vscode/account-resources.code-workspace
@@ -45,6 +45,7 @@
           "Codeable",
           "codeinline",
           "codesystem",
+          "CPSU",
           "DATETIME",
           "devcontainer",
           "esbuild",
@@ -92,7 +93,7 @@
           "URPID",
           "vars",
           "versionable",
-          "whens",
+          "whens"
         ],
     "cSpell.dictionaries": ["en-GB"],
     "cSpell.ignorePaths": ["package-lock.json","node_modules",".vscode"],

--- a/cloudformation/artillery_resources.yml
+++ b/cloudformation/artillery_resources.yml
@@ -285,6 +285,14 @@ Resources:
       Type: String
       Value: ChangeMe
 
+  ArtilleryCPSUApiKey:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: API key used for CPSU load testing
+      Name: /artilleryio/cpsu_api_key
+      Type: String
+      Value: ChangeMe
+
   ##################################################
   # VPC Security group, allowing outbound traffic (i.e. hit the test target), but forbids inbound traffic
   ##################################################


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change
- :warning: Potential issues that might be caused by this change

### Details

A secret I thought was stored in Github was actually an AWS secret. This adds it in.

Rather than wait for another release cut, there is also a change to the CI workflow that forces a release to REF. 