### PR TITLE
Fix: [AEA-4495] - no account id in s3

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -687,16 +687,16 @@ Resources:
           - s3:GetBucket*
           - s3:GetObject*
           Resource:
-          - !Sub arn:aws:s3::${AWS::AccountId}:cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2/*
-          - !Sub arn:aws:s3::${AWS::AccountId}:cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2
-          - !Sub arn:aws:s3::${AWS::AccountId}:cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/*
-          - !Sub arn:aws:s3::${AWS::AccountId}:cdk-hnb659fds-assets-${AWS::AccountId}-eu-east-1
+          - !Sub arn:aws:s3:::cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2/*
+          - !Sub arn:aws:s3:::cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2
+          - !Sub arn:aws:s3:::cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1/*
+          - !Sub arn:aws:s3:::cdk-hnb659fds-assets-${AWS::AccountId}-eu-east-1
           - !Sub arn:aws:lambda:*:${AWS::AccountId}:function:*CustomCrossRegionExport*
         - Effect: Allow
           Action: s3:List*
           Resource:
-          - !Sub arn:aws:s3::${AWS::AccountId}:cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2/*
-          - !Sub arn:aws:s3::${AWS::AccountId}:cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2
+          - !Sub arn:aws:s3:::cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2/*
+          - !Sub arn:aws:s3:::cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-2
 
   GrantCloudFormationExecutionEc2AccessPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- no need for account id in s3 resource