### PR TITLE
Chore: [AEA-4489] - Add concurrency alarm

### DIFF
--- a/.github/workflows/release_all_stacks.yml
+++ b/.github/workflows/release_all_stacks.yml
@@ -130,6 +130,22 @@ jobs:
       cf_create_changeset_role: ${{ secrets.cf_create_changeset_role }}
       cf_deploy_role: ${{ secrets.cf_deploy_role }}
 
+  list_alarms_resources_cf_changes:
+    uses: ./.github/workflows/cloudformation.yml
+    with:
+      env: ${{ inputs.target_environment }}
+      target_environment: ${{ inputs.target_environment }}-account
+      version: ${{ inputs.version }}
+      change_set_version: ${{ inputs.change_set_version }}
+      stack_name: alarms
+      template: ./cloudformation/alarms.yml
+      capabilities: CAPABILITY_NAMED_IAM
+      execute_change_set: ${{ inputs.execute_change_set }}
+    secrets:
+      parameter_secrets: "{}"
+      cf_create_changeset_role: ${{ secrets.cf_create_changeset_role }}
+      cf_deploy_role: ${{ secrets.cf_deploy_role }}
+    
 # ***************************************************
 # If you add a new stack for release, 
 # then you either need to manually deploy empty stack to int and prod

--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ It creates the following resources
 - an ECS cluster named "`artilleryio-cluster`"
 - a security group which allows outbound traffic, but forbids incoming traffic
 
+# alarms
+
+`cloudformation/alarms.yml` contains resources that are account wide. This should be applied to each environment, and should be deployed before the app.
+This is created as part of the CI pipeline.
+It creates the following resources
+
+- A concurrency alarm which monitors all traffic passing through the account, and triggers if it crosses a threshold.
+
 ## Parameters for stacks
 
 Environment specific parameters are defined in JSON files in cloudformation/env folder.

--- a/cloudformation/alarms.yml
+++ b/cloudformation/alarms.yml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  CloudFormation template for configuring CloudWatch alarms in the EPS account.
+  
+Parameters:
+  ConcurrencyThreshold:
+    Type: Number
+    Description: Threshold for the Lambda concurrency.
+    Default: 900
+    
+  EnableAlerts:
+    Type: String
+    AllowedValues: [ 'true', 'false' ]
+    Default: 'true'
+    Description: Whether to enable or disable alarms and notifications.
+  
+Resources:
+  EPSAccountConcurrencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties: 
+      AlarmName: EPS_Account_Concurrency_Alarm"
+      AlarmDescription: "Monitors the concurrency of all traffic coming through the EPS account, and triggers when concurrency exceeds the threshold."
+      Namespace: "AWS/Lambda"
+      MetricName: "ConcurrentExecutions"
+      Statistic: Maximum
+      Period: 300 # seconds
+      EvaluationPeriods: 1
+      Threshold: !Ref ConcurrencyThreshold
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      ActionsEnabled: !Ref EnableAlerts
+      AlarmActions:
+        - !ImportValue lambda-resources:SlackAlertsSnsTopicArn
+      InsufficientDataActions:
+        - !ImportValue lambda-resources:SlackAlertsSnsTopicArn
+      OKActions:
+        - !ImportValue lambda-resources:SlackAlertsSnsTopicArn


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change
- :sparkles: New Feature
- 
### Details

Adds a concurrency alarm, which sends a message on slack when it triggers. 

Needs manual INT and PROD deployments of empty stacks, since a new alarms config file is created.