### PR TITLE
Fix: [AEA-4732] - Amend Proxygen key outputs for the EPS FHIR API

### DIFF
--- a/cloudformation/secrets.yml
+++ b/cloudformation/secrets.yml
@@ -46,13 +46,13 @@ Outputs:
       Name: !Join [":", [!Ref "AWS::StackName", "PrescribingProxygenPublicKey"]]
 
   DispensingProxygenPrivateKey:
-    Description: PrescribingProxygenPrivateKey
-    Value: !GetAtt PrescribingProxygenPrivateKey.Id
+    Description: DispensingProxygenPrivateKey
+    Value: !GetAtt DispensingProxygenPrivateKey.Id
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", "DispensingProxygenPrivateKey"]]
 
   DispensingProxygenPublicKey:
-    Description: PrescribingProxygenPublicKey
-    Value: !GetAtt PrescribingProxygenPublicKey.Id
+    Description: DispensingProxygenPublicKey
+    Value: !GetAtt DispensingProxygenPublicKey.Id
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", "DispensingProxygenPublicKey"]]


### PR DESCRIPTION
## Summary

🎫 [AEA-4732](https://nhsd-jira.digital.nhs.uk/browse/AEA-4732) Amend Proxygen key outputs for the EPS FHIR API

- Routine Change

### Details

Update the Proxygen key outputs for the EPS FHIR API to ensure they return the correct values.