### PR TITLE
Fix: [AEA-5199] - Add permissions for deploying EventBridge

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -689,6 +689,12 @@ Resources:
               - ecr:GetLifecyclePolicy
               - ecr:DeleteLifecyclePolicy
               - ecr:PutLifecyclePolicy
+              - events:DescribeRule
+              - events:PutRule
+              - events:DeleteRule
+              - events:PutTargets
+              - events:RemoveTargets
+              - events:ListRules
             Resource: "*"
 
   GrantCloudFormationExecutionAccessPolicyD:


### PR DESCRIPTION
## Summary

- Routine Change

### Details

Missing some permissions to deploy stacks with an events bridge in them. This just adds them in.