### PR TITLE
Fix: [AEA-0000] - permissions for cdk push image to list scan coverage and findings

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -1332,6 +1332,12 @@ Resources:
             Action:
               - ecr:GetAuthorizationToken
             Resource: "*"
+          - Effect: Allow
+            Action:
+              - inspector2:ListCoverage
+              - inspector2:ListFindings
+            Resource: !Sub "arn:aws:inspector2:${AWS::Region}:${AWS::AccountId}:*"
+
 Outputs:
   ##################################################
   # Cloudformation Deployment Role Outputs


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- add permissions for cdk push image role to list scan and coverage findings