### PR TITLE
Chore: [AEA-5274] - Add missing permission for generating salt

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -538,6 +538,7 @@ Resources:
               - secretsmanager:Tag*
               - secretsmanager:Untag*
               - secretsmanager:GetSecretValue
+              - secretsmanager:GetRandomPassword
               - secretsmanager:PutResourcePolicy 
               - scheduler:GetSchedule
               - scheduler:CreateSchedule


### PR DESCRIPTION
## Summary

- Routine Change

### Details

The PSU notification SQS needs a random salt value for securely hashing sensitive data. To generate that, we need the `GetRandomPassword` permission, so this PR adds that.