### PR TITLE
New: [AEA-5308] - Add NHS notify secrets to the account-resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ It creates the following resources
     - ProxgenPublicKey - used to store the public key for proxygen
     - PSUProxygenPrivateKey - used to store the private key for deploying the PSU proxy via proxygen
     - PSUProxygenPublicKey - used to store the public key for deploying the PSU proxy via proxygen
+    - PSUNotifyCallbackAppName - used to store the DOS application name, for computing the NHS notify callback signature
+    - PSUNotifyCallbackApiKey - used to store NHS notify API key, for computing the NHS notify callback signature
     - CPSUProxygenPrivateKey - used to store the private key for deploying the CPSU proxy via proxygen
     - CPSUProxygenPublicKey - used to store the public key for deploying the CPSU proxy via proxygen
     - SlackWebHookUrl - used to store the slack webhook url needed for the Slack Alerter lambda to post to eps alert slack channels

--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -1182,6 +1182,26 @@ Resources:
       SecretString: ChangeMe
   #endregion
 
+  #region NHS Notify secrets
+  PSUNotifyCallbackAppName:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: The Digital Onboarding Service application name used when calculating the signature for the notify callback
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+      Name: !Sub "${AWS::StackName}-PSU-Notify-Application-Name"
+
+  PSUNotifyCallbackApiKey:
+    DependsOn: SecretsKMSKeyKMSKeyAlias
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: The API key used when calculating the signature for the NHS notify callback
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+      Name: !Sub "${AWS::StackName}-PSU-Notify-API-Key"
+  #endregion
+
   #region EPS FHIR Facade CA Secrets
   FhirFacadeCAKeySecret:
     DependsOn: SecretsKMSKeyKMSKeyAlias
@@ -1962,7 +1982,19 @@ Outputs:
     Value: !GetAtt ClinicalTrackerProxygenPublicKey.Id
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", "ClinicalTrackerProxygenPublicKey"]]
-  
+
+  PSUNotifyCallbackAppName:
+    Description: PSUNotifyCallbackAppName
+    Value: !GetAtt PSUNotifyCallbackAppName.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "PSUNotifyCallbackAppName"]]
+
+  PSUNotifyCallbackApiKey:
+    Description: PSUNotifyCallbackApiKey
+    Value: !GetAtt PSUNotifyCallbackApiKey.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "PSUNotifyCallbackApiKey"]]
+
   SlackWebHookUrl:
     Description: Slack webhook url
     Value: !GetAtt SlackWebHookUrl.Id

--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -152,6 +152,8 @@ Resources:
               - !ImportValue account-resources:PsuClientSandboxCertSecret
               - !ImportValue account-resources:PSUProxygenPrivateKey
               - !ImportValue account-resources:PSUProxygenPublicKey
+              - !ImportValue account-resources:PSUNotifyCallbackAppName
+              - !ImportValue account-resources:PSUNotifyCallbackApiKey
               - !ImportValue account-resources:CPSUProxygenPrivateKey
               - !ImportValue account-resources:CPSUProxygenPublicKey
               - !ImportValue account-resources:ClinicalTrackerClientKeySecret


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change

### Details

For each environment, deploy a single secret for the notify secrets (application name and api key). These will need to be manually updated to the real values.