### PR TITLE
Fix: [AEA-4769] - Add additional WAF CRUD permissions

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -868,7 +868,7 @@ Resources:
           - wafv2:GetRuleGroup
           - wafv2:UntagResource
           - wafv2:GetPermissionPolicy
-          - wafv2:ListTagsForResource"
+          - wafv2:ListTagsForResource
           - wafv2:ListIPSets
           - wafv2:GetIPSet
           - wafv2:CreateIPSet


### PR DESCRIPTION
## Summary

- :sparkles: New Feature

### Details

Add additional workflow permissions to the Cloudformation role, to enable CRUD operations on AWS WAF service.
Additionally allow Cloudfront distribution to associate a WAF ACL.
