### PR TITLE
Fix: [AEA-0000] - Add missing notify secrets

### DIFF
--- a/cloudformation/secrets.yml
+++ b/cloudformation/secrets.yml
@@ -84,6 +84,22 @@ Resources:
       SecretString: ChangeMe
       Name: !Sub "${AWS::StackName}-PSU-Notify-API-Key"
 
+  PSUNotifyPrivateKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: RSA private key (PEM) for signing JWT to NHS Notify
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+      Name: !Sub "${AWS::StackName}-PSU-Notify-PrivateKey"
+
+  PSUNotifyKidSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Key-ID (KID) header value for JWT to NHS Notify
+      KmsKeyId: alias/SecretsKMSKeyAlias
+      SecretString: ChangeMe
+      Name: !Sub "${AWS::StackName}-PSU-Notify-KID"
+
   GetNotifySecretsManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -96,45 +112,8 @@ Resources:
             Resource:
               - !Ref PSUNotifyCallbackAppName
               - !Ref PSUNotifyCallbackApiKey
-
-  NotifyApiKeySecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: NHS Notify API key for server-to-server token exchange
-      KmsKeyId: !ImportValue account-resources:SecretsKMSKeyAlias
-      SecretString: ChangeMe
-      Name: !Sub "${AWS::StackName}-Notify-ApiKey"
-
-  NotifyPrivateKeySecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: RSA private key (PEM) for signing JWT to NHS Notify
-      KmsKeyId: !ImportValue account-resources:SecretsKMSKeyAlias
-      SecretString: ChangeMe
-      Name: !Sub "${AWS::StackName}-Notify-PrivateKey"
-
-  NotifyKidSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: Key-ID (KID) header value for JWT to NHS Notify
-      KmsKeyId: !ImportValue account-resources:SecretsKMSKeyAlias
-      SecretString: ChangeMe
-      Name: !Sub "${AWS::StackName}-Notify-KID"
-
-  NotifyTokenExchangeSecretsPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      Description: Allows reading the Notify token exchange secrets
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action:
-              - secretsmanager:GetSecretValue
-            Resource:
-              - !Ref NotifyApiKeySecret
-              - !Ref NotifyPrivateKeySecret
-              - !Ref NotifyKidSecret
+              - !Ref PSUNotifyPrivateKeySecret
+              - !Ref PSUNotifyKidSecret
 
   #endregion
 
@@ -218,33 +197,22 @@ Outputs:
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", "PSUNotifyCallbackApiKey"]]
 
+  PSUNotifyPrivateKeySecret:
+    Description: NHS Notify Private Key secret ARN
+    Value: !GetAtt PSUNotifyPrivateKeySecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "PSUNotifyPrivateKeySecret"]]
+
+  PSUNotifyKidSecret:
+    Description: NHS Notify KID secret ARN
+    Value: !GetAtt PSUNotifyKidSecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "PSUNotifyKidSecret"]]
+
   GetNotifySecretsManagedPolicy:
     Description: "Access Notify Secrets Policy ARN"
     Value: !GetAtt GetNotifySecretsManagedPolicy.PolicyArn
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", "GetNotifySecretsManagedPolicy"]]
 
-  NotifyApiKeySecret:
-    Description: NHS Notify API key secret ARN
-    Value: !GetAtt NotifyApiKeySecret.Id
-    Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "NotifyApiKeySecret"]]
-
-  NotifyPrivateKeySecret:
-    Description: NHS Notify Private Key secret ARN
-    Value: !GetAtt NotifyPrivateKeySecret.Id
-    Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "NotifyPrivateKeySecret"]]
-
-  NotifyKidSecret:
-    Description: NHS Notify KID secret ARN
-    Value: !GetAtt NotifyKidSecret.Id
-    Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "NotifyKidSecret"]]
-
-  NotifyTokenExchangeSecretsPolicy:
-    Description: ARN of policy allowing Lambda to read NHS Notify secrets
-    Value: !GetAtt NotifyTokenExchangeSecretsPolicy.PolicyArn
-    Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "NotifyTokenExchangeSecretsPolicy"]]
   #endregion

--- a/cloudformation/secrets.yml
+++ b/cloudformation/secrets.yml
@@ -242,9 +242,9 @@ Outputs:
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", "NotifyKidSecret"]]
 
-  NotifyIntegrationSecretsPolicy:
+  NotifyTokenExchangeSecretsPolicy:
     Description: ARN of policy allowing Lambda to read NHS Notify secrets
-    Value: !GetAtt NotifyIntegrationSecretsPolicy.Arn
+    Value: !GetAtt NotifyTokenExchangeSecretsPolicy.PolicyArn
     Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "NotifyIntegrationSecretsPolicy"]]
+      Name: !Join [":", [!Ref "AWS::StackName", "NotifyTokenExchangeSecretsPolicy"]]
   #endregion

--- a/cloudformation/secrets.yml
+++ b/cloudformation/secrets.yml
@@ -96,6 +96,46 @@ Resources:
             Resource:
               - !Ref PSUNotifyCallbackAppName
               - !Ref PSUNotifyCallbackApiKey
+
+  NotifyApiKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: NHS Notify API key for server-to-server token exchange
+      KmsKeyId: !ImportValue account-resources:SecretsKMSKeyAlias
+      SecretString: ChangeMe
+      Name: !Sub "${AWS::StackName}-Notify-ApiKey"
+
+  NotifyPrivateKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: RSA private key (PEM) for signing JWT to NHS Notify
+      KmsKeyId: !ImportValue account-resources:SecretsKMSKeyAlias
+      SecretString: ChangeMe
+      Name: !Sub "${AWS::StackName}-Notify-PrivateKey"
+
+  NotifyKidSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Key-ID (KID) header value for JWT to NHS Notify
+      KmsKeyId: !ImportValue account-resources:SecretsKMSKeyAlias
+      SecretString: ChangeMe
+      Name: !Sub "${AWS::StackName}-Notify-KID"
+
+  NotifyTokenExchangeSecretsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allows reading the Notify token exchange secrets
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - secretsmanager:GetSecretValue
+            Resource:
+              - !Ref NotifyApiKeySecret
+              - !Ref NotifyPrivateKeySecret
+              - !Ref NotifyKidSecret
+
   #endregion
 
 Outputs:
@@ -183,4 +223,28 @@ Outputs:
     Value: !GetAtt GetNotifySecretsManagedPolicy.PolicyArn
     Export:
       Name: !Join [":", [!Ref "AWS::StackName", "GetNotifySecretsManagedPolicy"]]
+
+  NotifyApiKeySecret:
+    Description: NHS Notify API key secret ARN
+    Value: !GetAtt NotifyApiKeySecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "NotifyApiKeySecret"]]
+
+  NotifyPrivateKeySecret:
+    Description: NHS Notify Private Key secret ARN
+    Value: !GetAtt NotifyPrivateKeySecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "NotifyPrivateKeySecret"]]
+
+  NotifyKidSecret:
+    Description: NHS Notify KID secret ARN
+    Value: !GetAtt NotifyKidSecret.Id
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "NotifyKidSecret"]]
+
+  NotifyIntegrationSecretsPolicy:
+    Description: ARN of policy allowing Lambda to read NHS Notify secrets
+    Value: !GetAtt NotifyIntegrationSecretsPolicy.Arn
+    Export:
+      Name: !Join [":", [!Ref "AWS::StackName", "NotifyIntegrationSecretsPolicy"]]
   #endregion


### PR DESCRIPTION
## Summary

- Routine Change

### Details

The NHS Notify endpoint needs an OAUTH2 bearer token. This adds some secrets necessary to making that work.