### PR TITLE
Fix: [AEA-5614] - add devops policy and policy to decrypt kms keys

### DIFF
--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -1475,6 +1475,89 @@ Resources:
             Resource: "*"
   #endregion
 
+  #region EPSReadOnlyKMSPolicy
+  # policy to allow readonly role access to decrypt using kms keys
+  EPSReadOnlyKMSDecryptPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: EPSReadOnlyKMSDecryptPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: 
+              - !Sub arn:aws:kms:eu-west-2:${AWS::AccountId}:key/*
+  #endregion
+
+
+  #region EPSDevopsPolicy
+  # policy to allow access to common devops tasks
+  # currently this is to do KOP-015 and manage codebuild deployments
+  EPSDevopsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: EPSDevopsPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - kms:DescribeKey
+              - kms:GenerateDataKey*
+              - kms:Encrypt
+              - kms:ReEncrypt*
+              - kms:Decrypt
+            Resource: !GetAtt TrustStoreBucketKMSKey.Arn
+          - Effect: Allow
+            Action:
+              - s3:GetObject*
+              - s3:PutObject*
+              - s3:GetBucket*
+              - s3:List*
+            Resource:
+              - !Join ["", [!GetAtt TrustStoreBucket.Arn, "/*"]]
+              - !GetAtt TrustStoreBucket.Arn
+          - Effect: Allow
+            Action:
+              - secretsmanager:PutSecretValue
+            Resource:
+              - !Ref PfpCAKeySecret
+              - !Ref PfpCACertSecret
+              - !Ref PfpClientKeySecret
+              - !Ref PfpClientCertSecret
+              - !Ref PfpClientSandboxKeySecret
+              - !Ref PfpClientSandboxCertSecret
+              - !Ref ClinicalTrackerCAKeySecret
+              - !Ref ClinicalTrackerCACertSecret
+              - !Ref ClinicalTrackerClientKeySecret
+              - !Ref ClinicalTrackerClientCertSecret
+              - !Ref ClinicalTrackerClientSandboxKeySecret
+              - !Ref ClinicalTrackerClientSandboxCertSecret
+              - !Ref PsuCAKeySecret
+              - !Ref PsuCACertSecret
+              - !Ref PsuClientKeySecret
+              - !Ref PsuClientCertSecret
+              - !Ref PsuClientSandboxKeySecret
+              - !Ref PsuClientSandboxCertSecret
+              - !Ref FhirFacadeCAKeySecret
+              - !Ref FhirFacadeCACertSecret
+              - !Ref FhirFacadeClientKeySecret
+              - !Ref FhirFacadeClientCertSecret
+              - !Ref FhirFacadeClientSandboxKeySecret
+              - !Ref FhirFacadeClientSandboxCertSecret
+          - Effect: Allow
+            Resource: "*"
+            Action:
+              - codepipeline:PutApprovalResult
+              - codepipeline:RetryStageExecution
+              - codepipeline:RollbackStage
+              - codepipeline:StartPipelineExecution
+              - codepipeline:StopPipelineExecution
+
+  #endregion
+
   # region inspector filters
   # these are CVEs that should be ignored when scanning container images uploaded to ECR
   # we should only add items into here when the vulnerability is not one that affects us,


### PR DESCRIPTION
## Summary

- Routine Change

### Details
- add policy to decrypt kms keys that can be added to read only role
- add devops policy to do common tasks