### PR TITLE
Chore: [AEA-0000] - Add BucketNotificationsHandler policy to CloudFormation execution role

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -958,6 +958,7 @@ Resources:
           - !Sub arn:aws:lambda:*:${AWS::AccountId}:function:*CustomS3AutoDeleteObject*
           - !Sub arn:aws:lambda:*:${AWS::AccountId}:function:*AWS679f53fac002430cb0da5*
           - !Sub arn:aws:lambda:*:${AWS::AccountId}:function:*CustomVpcRestrictDefaultSG*
+          - !Sub arn:aws:lambda:*:${AWS::AccountId}:function:*BucketNotificationsHandler*
         - Effect: Allow
           Action: s3:List*
           Resource:


### PR DESCRIPTION
## Summary

- Routine Change

### Details
This change adds the `BucketNotificationsHandler` policy to the existing CloudFormation execution role, granting `lambda:InvokeFunction` permission for CDK-generated `BucketNotificationsHandler` Lambdas to enable S3 event notification configuration during deployment.