### PR TITLE
Fix: [AEA-0000] - limit proxygen error logging to not log full request body

### DIFF
--- a/packages/proxygen/src/helpers.ts
+++ b/packages/proxygen/src/helpers.ts
@@ -50,7 +50,7 @@ export function proxygenErrorHandler(error: unknown, logger: Logger) {
       stack: error.stack,
       message: error.message,
       config: {
-        data: error.config?.data,
+        data: (error.config?.data ?? "").toString().slice(0, 255), // limit to first 255 chars as it may be full spec
         headers: error.config?.headers,
         method: error.config?.method,
         url: error.config?.url

--- a/packages/proxygen/tests/proxygenInstanceDelete.test.ts
+++ b/packages/proxygen/tests/proxygenInstanceDelete.test.ts
@@ -95,7 +95,7 @@ describe("Unit test for proxygenInstanceDelete", function () {
         status: 500,
         message: "Request failed with status code 500",
         config: {
-          data: undefined,
+          data: "",
           headers: expect.objectContaining({
             Accept: "application/json, text/plain, */*",
             "Content-Type": "application/json",
@@ -142,7 +142,7 @@ describe("Unit test for proxygenInstanceDelete", function () {
       axiosError: expect.objectContaining({
         message: "Something awful happened",
         config: {
-          data: undefined,
+          data: "",
           headers: expect.objectContaining({
             Accept: "application/json, text/plain, */*",
             "Content-Type": "application/json",

--- a/packages/proxygen/tests/proxygenInstanceGet.test.ts
+++ b/packages/proxygen/tests/proxygenInstanceGet.test.ts
@@ -93,7 +93,7 @@ describe("Unit test for proxygenInstanceGet", function () {
         status: 500,
         message: "Request failed with status code 500",
         config: {
-          data: undefined,
+          data: "",
           headers: expect.objectContaining({
             Accept: "application/json, text/plain, */*",
             "Content-Type": "application/json",
@@ -139,7 +139,7 @@ describe("Unit test for proxygenInstanceGet", function () {
       axiosError: expect.objectContaining({
         message: "Something awful happened",
         config: {
-          data: undefined,
+          data: "",
           headers: expect.objectContaining({
             Accept: "application/json, text/plain, */*",
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- limit proxygen error logging to only log first 255 chars of request body to prevent log loss