### PR TITLE
Fix: [AEA-5352] - Update policy to allow PutLifecyclePermissions

### DIFF
--- a/cloudformation/ci_resources.yml
+++ b/cloudformation/ci_resources.yml
@@ -240,7 +240,7 @@ Resources:
               - cloudfront-keyvaluestore:UpdateKeys
               - cloudfront:CreateInvalidation
             Resource: "*"
-  
+
   ##################################################
   # Cloudformation Execution Role
   ##################################################
@@ -282,7 +282,7 @@ Resources:
           - Effect: Allow
             Action:
               - sts:AssumeRole
-            Resource: 
+            Resource:
               - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-us-east-1
               - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-eu-west-2
               - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-us-east-1
@@ -490,7 +490,7 @@ Resources:
               - aoss:GetSecurityPolicy
               - aoss:UpdateSecurityPolicy
               - aoss:CreateAccessPolicy
-              - aoss:DeleteAccessPolicy 
+              - aoss:DeleteAccessPolicy
               - aoss:GetAccessPolicy
               - aoss:UpdateAccessPolicy
               - aoss:CreateCollection
@@ -512,7 +512,7 @@ Resources:
               - bedrock:UpdateGuardrail
               - bedrock:GetGuardrail
               - bedrock:DeleteGuardrail
-              - bedrock:AssociateAgentKnowledgeBase 
+              - bedrock:AssociateAgentKnowledgeBase
               - bedrock:CreateKnowledgeBase
               - bedrock:DeleteKnowledgeBase
               - bedrock:DeleteKnowledgeBaseDocuments
@@ -522,7 +522,7 @@ Resources:
               - bedrock:GetKnowledgeBaseDocuments
               - bedrock:IngestKnowledgeBaseDocuments
               - bedrock:ListAgentKnowledgeBases
-              - bedrock:ListKnowledgeBaseDocuments 
+              - bedrock:ListKnowledgeBaseDocuments
               - bedrock:ListKnowledgeBases
               - bedrock:UpdateAgentKnowledgeBase
               - bedrock:UpdateKnowledgeBase
@@ -577,6 +577,7 @@ Resources:
               - s3:GetBucketVersioning
               - s3:GetBucketWebsite
               - s3:PutBucketOwnershipControls
+              - s3:PutLifecycleConfiguration
               - firehose:CreateDeliveryStream
               - firehose:DescribeDeliveryStream
               - firehose:DeleteDeliveryStream
@@ -609,8 +610,8 @@ Resources:
               - secretsmanager:Untag*
               - secretsmanager:GetSecretValue
               - secretsmanager:GetRandomPassword
-              - secretsmanager:PutResourcePolicy 
-              - secretsmanager:GetResourcePolicy 
+              - secretsmanager:PutResourcePolicy
+              - secretsmanager:GetResourcePolicy
               - scheduler:GetSchedule
               - scheduler:CreateSchedule
               - scheduler:DeleteSchedule
@@ -812,7 +813,7 @@ Resources:
               - wafv2:ListLoggingConfigurations
               - wafv2:PutLoggingConfiguration
               - cloudfront:AllowVendedLogDeliveryForResource
-            Resource: 
+            Resource:
               - "*"
               - !Sub arn:aws:lambda:*:${AWS::AccountId}:function:*BucketNotificationsHandler*
 
@@ -1201,7 +1202,7 @@ Resources:
           - Effect: Allow
             Action:
               - sts:AssumeRole
-            Resource: 
+            Resource:
               - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-hnb659fds-lookup-role-${AWS::AccountId}-us-east-1
               - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-hnb659fds-lookup-role-${AWS::AccountId}-eu-west-2
               - !Sub arn:aws:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-us-east-1


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change

### Details

In merge to main: 
```
The resource AuditLoggingBucket is in a UPDATE_FAILED state

This AWS::S3::Bucket resource is in a UPDATE_FAILED state.

Resource handler returned message: "User: arn:aws:sts::591291862413:assumed-role/ci-resources-CloudFormationExecutionRole-1A9D0GXNWHPW2/AWSCloudFormation is not authorized to perform: s3:PutLifecycleConfiguration on resource: "arn:aws:s3:::ci-resources-auditloggingbucket-qinzx9hzgs2j" because no identity-based policy allows the s3:PutLifecycleConfiguration action (Service: S3, Status Code: 403, Request ID: TBA9RX7M937PK70Z, Extended Request ID: 0PQhbBDaqOau/1onQA7N3Ku2F3NVPPw88G2VD/Heu7ZipU2OQMzwG11cQEcf9nZJrSDRCY7v4VRJcpUyc9nJCQ==) (SDK Attempt Count: 1)" (RequestToken: 893b4953-0574-4199-5e54-8710f61f1104, HandlerErrorCode: GeneralServiceException)
```

This adds the missing permission. I've rebased to the last good build for account-resources, so I can check that the update to include lifecycles will integrate okay.
