### PR TITLE
Fix: [AEA-3532] - Increase log retention time

### DIFF
--- a/environmentSettings/dev.json
+++ b/environmentSettings/dev.json
@@ -76,7 +76,7 @@
       "EnableDeleteCNAME": "true"
     },
     "account-resources": {
-      "LogRetentionDays": "30"
+      "LogRetentionDays": "90"
     },
     "lambda-resources": {
       "SplunkHECEndpoint": "https://firehose.inputs.splunk.aws.digital.nhs.uk/services/collector/event",

--- a/environmentSettings/int.json
+++ b/environmentSettings/int.json
@@ -63,7 +63,7 @@
       "EnableDeleteCNAME": "false"
     },
     "account-resources": {
-      "LogRetentionDays": "30"
+      "LogRetentionDays": "90"
     },
     "lambda-resources": {
       "SplunkHECEndpoint": "https://firehose.inputs.splunk.aws.digital.nhs.uk/services/collector/event",

--- a/environmentSettings/prod.json
+++ b/environmentSettings/prod.json
@@ -70,7 +70,7 @@
       "EnableDeleteCNAME": "false"
     },
     "account-resources": {
-      "LogRetentionDays": "30"
+      "LogRetentionDays": "90"
     },
     "lambda-resources": {
       "SplunkHECEndpoint": "https://firehose.inputs.splunk.aws.digital.nhs.uk/services/collector/event",

--- a/environmentSettings/qa.json
+++ b/environmentSettings/qa.json
@@ -60,7 +60,7 @@
       "EnableDeleteCNAME": "false"
     },
     "account-resources": {
-      "LogRetentionDays": "30"
+      "LogRetentionDays": "90"
     },
     "lambda-resources": {
       "SplunkHECEndpoint": "https://firehose.inputs.splunk.aws.digital.nhs.uk/services/collector/event",

--- a/environmentSettings/ref.json
+++ b/environmentSettings/ref.json
@@ -65,7 +65,7 @@
       "EnableDeleteCNAME": "false"
     },
     "account-resources": {
-      "LogRetentionDays": "30"
+      "LogRetentionDays": "90"
     },
     "lambda-resources": {
       "SplunkHECEndpoint": "https://firehose.inputs.splunk.aws.digital.nhs.uk/services/collector/event",


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change

### Details

```
Resource handler returned message: "'Days' in the Expiration action for filter '(prefix=)' must be greater than 'Days' in the Transition action (Service: S3, Status Code: 400, Request ID: 2ZPBBZVD25XV25ZT, Extended Request ID: H2bdkbTI3hzuGz7CoZWUSEYviF7Oe5nOYtQENt1JABW/Xh/MIomiQUg1k8Di282ZSmrqxB7aEl4=) (SDK Attempt Count: 1)" (RequestToken: 9eec6598-1153-0d0b-1566-5d2ba016416d, HandlerErrorCode: InvalidRequest)
```

Seems that transition time cannot be equal to expiry time. Increase the latter to 90 days.