### PR TITLE
Chore: [AEA-6257] - remove unused service search v2 api key, add new v3

### DIFF
--- a/.github/instructions/languages/sam.instructions.md
+++ b/.github/instructions/languages/sam.instructions.md
@@ -158,6 +158,7 @@ Environment:
     SpinePublicCertificateARN: !ImportValue account-resources:SpinePublicCertificate
     # Service search
     TargetServiceSearchServer: !Ref TargetServiceSearchServer
+    ServiceSearch3ApiKeyARN: !ImportValue secrets-cdk:Secrets:ServiceSearch3ApiKey:Arn
 ```
 
 ### Logging Configuration

--- a/.github/instructions/languages/sam.instructions.md
+++ b/.github/instructions/languages/sam.instructions.md
@@ -158,7 +158,6 @@ Environment:
     SpinePublicCertificateARN: !ImportValue account-resources:SpinePublicCertificate
     # Service search
     TargetServiceSearchServer: !Ref TargetServiceSearchServer
-    ServiceSearchApiKeyARN: !ImportValue account-resources:ServiceSearchApiKey
 ```
 
 ### Logging Configuration

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ It creates the following resources
     - SpineASID - used to store the spine ASID
     - SpinePartyKey - used to store the spine party key
     - SpineCAChain - used to store the spine CA chain
-    - ServiceSearchApiKey - used to store the service search API key
     - JiraToken - used to store token for jira
     - ConfluenceToken - used to store token for confluence
     - ProxgenPrivateKey - used to store the private key for proxygen

--- a/SAMtemplates/lambda_resources_bootstrap.yaml
+++ b/SAMtemplates/lambda_resources_bootstrap.yaml
@@ -10,7 +10,7 @@ Globals:
     MemorySize: 256
     Architectures:
       - x86_64
-    Runtime: nodejs20.x
+    Runtime: nodejs24.x
     Environment:
       Variables:
         NODE_OPTIONS: "--enable-source-maps"

--- a/cloudformation/account_resources.yml
+++ b/cloudformation/account_resources.yml
@@ -1547,14 +1547,6 @@ Resources:
   #endregion
 
   #region Other Secrets
-  ServiceSearchApiKey:
-    DependsOn: SecretsKMSKeyKMSKeyAlias
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: API key for service search
-      KmsKeyId: alias/SecretsKMSKeyAlias
-      SecretString: ChangeMe
-
   JiraToken:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
@@ -1833,7 +1825,6 @@ Resources:
               - !Ref SpineASID
               - !Ref SpinePartyKey
               - !Ref SpineCAChain
-              - !Ref ServiceSearchApiKey
 
   SplunkHECToken:
     DependsOn: SecretsKMSKeyKMSKeyAlias
@@ -2409,12 +2400,6 @@ Outputs:
   #endregion
 
   #region Other Secrets Outputs
-  ServiceSearchApiKey:
-    Description: ServiceSearchApiKey
-    Value: !GetAtt ServiceSearchApiKey.Id
-    Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "ServiceSearchApiKey"]]
-
   JiraToken:
     Description: JiraToken
     Value: !GetAtt JiraToken.Id

--- a/cloudformation/account_resources_bootstrap.yml
+++ b/cloudformation/account_resources_bootstrap.yml
@@ -374,14 +374,6 @@ Resources:
   #endregion
 
   #region Other Secrets
-  ServiceSearchApiKey:
-    DependsOn: SecretsKMSKeyKMSKeyAlias
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Description: API key for service search
-      KmsKeyId: alias/SecretsKMSKeyAlias
-      SecretString: ChangeMe
-
   JiraToken:
     DependsOn: SecretsKMSKeyKMSKeyAlias
     Type: AWS::SecretsManager::Secret
@@ -471,7 +463,6 @@ Resources:
               - !Ref SpineASID
               - !Ref SpinePartyKey
               - !Ref SpineCAChain
-              - !Ref ServiceSearchApiKey
 
   SplunkHECToken:
     DependsOn: SecretsKMSKeyKMSKeyAlias
@@ -746,12 +737,6 @@ Outputs:
   #endregion
 
   #region Other Secrets Outputs
-  ServiceSearchApiKey:
-    Description: ServiceSearchApiKey
-    Value: !GetAtt ServiceSearchApiKey.Id
-    Export:
-      Name: !Join [":", [!Ref "AWS::StackName", "ServiceSearchApiKey"]]
-
   JiraToken:
     Description: JiraToken
     Value: !GetAtt JiraToken.Id

--- a/cloudformation/account_resources_bootstrap.yml
+++ b/cloudformation/account_resources_bootstrap.yml
@@ -463,6 +463,7 @@ Resources:
               - !Ref SpineASID
               - !Ref SpinePartyKey
               - !Ref SpineCAChain
+              - !ImportValue secrets-cdk:Secrets:ServiceSearch3ApiKey:Arn
 
   SplunkHECToken:
     DependsOn: SecretsKMSKeyKMSKeyAlias

--- a/packages/cdk/resources/ConfigSecrets.ts
+++ b/packages/cdk/resources/ConfigSecrets.ts
@@ -1,0 +1,24 @@
+
+import {IKey} from "aws-cdk-lib/aws-kms"
+import {Construct} from "constructs"
+import {StaticSecret} from "../constructs/StaticSecret"
+import {Secret} from "aws-cdk-lib/aws-secretsmanager"
+
+export interface ConfigSecretsProps {
+  readonly stackName: string
+  readonly configSecretsKmsKey: IKey
+}
+export class ConfigSecrets extends Construct {
+  public readonly serviceSearch3ApiKey: Secret
+
+  public constructor(scope: Construct, id: string, props: ConfigSecretsProps){
+    super(scope, id)
+    const serviceSearch3ApiKey = new StaticSecret(this, "ServiceSearch3ApiKey", {
+      secretName:  `${props.stackName}-ServiceSearch3ApiKey`,
+      description: "Service Search 3 API Key",
+      encryptionKey: props.configSecretsKmsKey
+    })
+
+    this.serviceSearch3ApiKey = serviceSearch3ApiKey.secret
+  }
+}

--- a/packages/cdk/resources/ExportMigrations.ts
+++ b/packages/cdk/resources/ExportMigrations.ts
@@ -652,18 +652,6 @@ const exportValues: { [key: string]: ExportValue } = {
     prod:
       "alias/SecretsKMSKeyAlias"
   },
-  "account-resources:ServiceSearchApiKey": {
-    dev:
-      "arn:aws:secretsmanager:eu-west-2:591291862413:secret:ServiceSearchApiKey-L1Yz7eJVrEIe-R7D494",
-    ref:
-      "arn:aws:secretsmanager:eu-west-2:158471595810:secret:ServiceSearchApiKey-0UxJjamgAQYs-t8Eowl",
-    qa:
-      "arn:aws:secretsmanager:eu-west-2:394382261442:secret:ServiceSearchApiKey-Zs7o3MVIGRJG-JJMjsE",
-    int:
-      "arn:aws:secretsmanager:eu-west-2:399793560585:secret:ServiceSearchApiKey-crcKn9ohTqwR-l1kEkw",
-    prod:
-      "arn:aws:secretsmanager:eu-west-2:434629240718:secret:ServiceSearchApiKey-TtpNiKjpPP5t-fhvN92"
-  },
   "account-resources:SNSFeedbackLoggingRoleArn": {
     dev:
       "arn:aws:iam::591291862413:role/account-resources-SNSFeedbackLoggingRole-JU3IlNDbdZML",

--- a/packages/cdk/stacks/SecretsStack.ts
+++ b/packages/cdk/stacks/SecretsStack.ts
@@ -8,7 +8,7 @@ import {
 import {Alias} from "aws-cdk-lib/aws-kms"
 import {nagSuppressions} from "../nagSuppressions"
 import {getExportValue} from "../resources/ExportMigrations"
-import {StaticSecret} from "../constructs/StaticSecret"
+import {ConfigSecrets} from "../resources/ConfigSecrets"
 
 export interface SecretsStackProps extends StackProps {
   readonly stackName: string
@@ -26,6 +26,18 @@ export class SecretsStack extends Stack {
     // this will be imported into here
     // const regressionTestSecrets =
     // new RegressionTestSecrets(this, "RegressionTestSecrets", {stackName: props.stackName})
+
+    // new, unmigrated secrets
+    const secretsKmsKey = Alias.fromAliasName(
+      this,
+      "SecretsKMSKeyAliasLookup",
+      getExportValue("account-resources:SecretsKMSKeyAlias", props.environment)
+    )
+
+    const configSecrets = new ConfigSecrets(this, "ConfigSecrets", {
+      stackName: props.stackName,
+      configSecretsKmsKey: secretsKmsKey
+    })
 
     // policy exports
     new CfnOutput(this, "AccessSlackSecretsManagedPolicyArn", {
@@ -347,19 +359,8 @@ export class SecretsStack extends Stack {
       exportName: `${props.stackName}:Secrets:ConfluenceToken:Arn`
     })
 
-    // new, unmigrated secrets
-    const secretsKmsKey = Alias.fromAliasName(
-      this,
-      "SecretsKMSKeyAliasLookup",
-      getExportValue("account-resources:SecretsKMSKeyAlias", props.environment)
-    )
-    const serviceSearch3ApiKey = new StaticSecret(this, "ServiceSearch3ApiKey", {
-      secretName:  `${props.stackName}-ServiceSearch3ApiKey`,
-      description: "Service Search 3 API Key",
-      encryptionKey: secretsKmsKey
-    })
     new CfnOutput(this, "ServiceSearch3ApiKeyArn", {
-      value: serviceSearch3ApiKey.secret.secretArn,
+      value: configSecrets.serviceSearch3ApiKey.secretArn,
       exportName: `${props.stackName}:Secrets:ServiceSearch3ApiKey:Arn`
     })
 

--- a/packages/cdk/stacks/SecretsStack.ts
+++ b/packages/cdk/stacks/SecretsStack.ts
@@ -338,6 +338,15 @@ export class SecretsStack extends Stack {
       exportName: `${props.stackName}:Secrets:AllowCloudFormationSecretsAccessManagedPolicy:Arn`
     })
 
+    new CfnOutput(this, "JiraTokenArn", {
+      value: getExportValue("account-resources:JiraToken", props.environment),
+      exportName: `${props.stackName}:Secrets:JiraToken:Arn`
+    })
+    new CfnOutput(this, "ConfluenceTokenArn", {
+      value: getExportValue("account-resources:ConfluenceToken", props.environment),
+      exportName: `${props.stackName}:Secrets:ConfluenceToken:Arn`
+    })
+
     // new, unmigrated secrets
     const secretsKmsKey = Alias.fromAliasName(
       this,

--- a/packages/cdk/stacks/SecretsStack.ts
+++ b/packages/cdk/stacks/SecretsStack.ts
@@ -5,8 +5,10 @@ import {
   Tags,
   CfnOutput
 } from "aws-cdk-lib"
+import {Alias} from "aws-cdk-lib/aws-kms"
 import {nagSuppressions} from "../nagSuppressions"
 import {getExportValue} from "../resources/ExportMigrations"
+import {StaticSecret} from "../constructs/StaticSecret"
 
 export interface SecretsStackProps extends StackProps {
   readonly stackName: string
@@ -222,10 +224,6 @@ export class SecretsStack extends Stack {
       value: getExportValue("account-resources:PSUProxygenPublicKey", props.environment),
       exportName: `${props.stackName}:Secrets:PSUProxygenPublicKey:Arn`
     })
-    new CfnOutput(this, "ServiceSearchApiKeyArn", {
-      value: getExportValue("account-resources:ServiceSearchApiKey", props.environment),
-      exportName: `${props.stackName}:Secrets:ServiceSearchApiKey:Arn`
-    })
     new CfnOutput(this, "SpineASIDArn", {
       value: getExportValue("account-resources:SpineASID", props.environment),
       exportName: `${props.stackName}:Secrets:SpineASID:Arn`
@@ -339,6 +337,23 @@ export class SecretsStack extends Stack {
       value: getExportValue("ci-resources:AllowCloudFormationSecretsAccessManagedPolicy", props.environment),
       exportName: `${props.stackName}:Secrets:AllowCloudFormationSecretsAccessManagedPolicy:Arn`
     })
+
+    // new, unmigrated secrets
+    const secretsKmsKey = Alias.fromAliasName(
+      this,
+      "SecretsKMSKeyAliasLookup",
+      getExportValue("account-resources:SecretsKMSKeyAlias", props.environment)
+    )
+    const serviceSearch3ApiKey = new StaticSecret(this, "ServiceSearch3ApiKey", {
+      secretName:  `${props.stackName}-ServiceSearch3ApiKey`,
+      description: "Service Search 3 API Key",
+      encryptionKey: secretsKmsKey
+    })
+    new CfnOutput(this, "ServiceSearch3ApiKeyArn", {
+      value: serviceSearch3ApiKey.secret.secretArn,
+      exportName: `${props.stackName}:Secrets:ServiceSearch3ApiKey:Arn`
+    })
+
     nagSuppressions(this, "Secrets")
   }
 }

--- a/scripts/set_aws_secrets.py
+++ b/scripts/set_aws_secrets.py
@@ -111,12 +111,6 @@ def get_secret_arns_and_local_values(all_exports: list, environment: str) -> lis
             "local_value": read_local_secret(f"{environment}/eps_signing_cert_chain")
         },
         {
-            "variable_name": "service_search_api_key",
-            "export_name": "account-resources:ServiceSearchApiKey",
-            "required": True,
-            "local_value": os.environ.get(f"{environment}_service_search_api_key")
-        },
-        {
             "variable_name": "PSU_proxygen_private_key",
             "export_name": "account-resources:PSUProxygenPrivateKey",
             "required": True,
@@ -187,6 +181,13 @@ def get_secret_arns_and_local_values(all_exports: list, environment: str) -> lis
             "export_name": "secrets:ptlPrescriptionSigningPrivateKey",
             "required": True,
             "local_value": read_local_secret(f"{environment}/ptl_prescription_signing_private_key")
+        },
+        # new, cdk managed secrets
+        {
+            "variable_name": "service_search_api_key",
+            "export_name": "secrets-cdk:Secrets:ServiceSearch3ApiKey:Arn",
+            "required": True,
+            "local_value": os.environ.get(f"{environment}_service_search_api_key")
         },
     ]
 


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change

### Details

Remove unused Service Search v2 API key secret and create a new CDK-managed one for v3
On rollout the value in SecretsManager for `pfp-PfP-ServiceSearch-API-Key` needs to be copied to `secrets-cdk:Secrets:ServiceSearch3ApiKey`